### PR TITLE
Add projects/client to build client jar

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -96,6 +96,14 @@ Include REFINE to refine the spec
 	   - replace hato usage with http-client
 	   - remove the hato dependency
 
+- [x] add projects/client to build a client jar
+        - include the mcp-client component
+
+- [ ] add projects/java-sdk-wrapper to build a jar with the SDK interop
+      component
+
+- [ ] add a github action to run the tests
+
 - [ ] extend the interop to enable use of SSE transport ? not sure this
       is worth doing still
 

--- a/.cljstyle
+++ b/.cljstyle
@@ -1,20 +1,21 @@
-{:rules {:blank-lines {:max-consecutive   1
-                       :trim-consecutive? true
-                       :padding-lines     1
-                       :insert-padding?   true}
-         :whitespace  {:remove-surrounding? true
-                       :remove-trailing?    true
-                       :insert-missing?     true}
-         :eof-newline {:enabled?         true
-                       :trailing-blanks? false}
-         :comments    {#_#_:inline-prefix  " "
-                       #_#_:leading-prefix " "}
-         :vars        {:enabled? true}
-         :functions   {:enabled? true}
-         :types       {:types?     true
-                       :protocols? true
-                       :reifies?   true
-                       :proxies?   true}
-         :namespaces  {:indent-size        0
-                       :break-libs?        true
-                       :import-break-width 0}}}
+{:files   {:extensions #{".clj" ".cljs" ".cljc" ".edn"}}
+ :rules   {:blank-lines {:max-consecutive   1
+                         :trim-consecutive? true
+                         :padding-lines     1
+                         :insert-padding?   true}
+           :whitespace  {:remove-surrounding? true
+                         :remove-trailing?    true
+                         :insert-missing?     true}
+           :eof-newline {:enabled?         true
+                         :trailing-blanks? false}
+           :comments    {#_#_:inline-prefix  " "
+                         #_#_:leading-prefix " "}
+           :vars        {:enabled? true}
+           :functions   {:enabled? true}
+           :types       {:types?     true
+                         :protocols? true
+                         :reifies?   true
+                         :proxies?   true}
+           :namespaces  {:indent-size        0
+                         :break-libs?        true
+                         :import-break-width 0}}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,4 +182,5 @@ clj -M:stdio-server
 - mcp protocol specification is at
   https://github.com/modelcontextprotocol/modelcontextprotocol/tree/main/docs/specification
 
-- use str/includes? rather than .contains
+- use `str/includes?` rather than `.contains`
+- run `cljstyle fix` before committing

--- a/components/http-client/src/mcp_clj/http_client/core.clj
+++ b/components/http-client/src/mcp_clj/http_client/core.clj
@@ -1,18 +1,18 @@
 (ns mcp-clj.http-client.core
   "HTTP client implementation using JDK HttpClient"
   (:require
-   [clojure.data.json :as json]
-   [clojure.string :as str])
+    [clojure.data.json :as json]
+    [clojure.string :as str])
   (:import
-   (java.net
-    URI)
-   (java.net.http
-    HttpClient
-    HttpRequest
-    HttpRequest$BodyPublishers
-    HttpResponse$BodyHandlers)
-   (java.time
-    Duration)))
+    (java.net
+      URI)
+    (java.net.http
+      HttpClient
+      HttpRequest
+      HttpRequest$BodyPublishers
+      HttpResponse$BodyHandlers)
+    (java.time
+      Duration)))
 
 ;; HTTP Client Creation
 
@@ -28,14 +28,14 @@
        (.connectTimeout builder (Duration/ofMillis connect-timeout)))
      (case follow-redirects
        :never  (.followRedirects
-                builder
-                java.net.http.HttpClient$Redirect/NEVER)
+                 builder
+                 java.net.http.HttpClient$Redirect/NEVER)
        :always (.followRedirects
-                builder
-                java.net.http.HttpClient$Redirect/ALWAYS)
+                 builder
+                 java.net.http.HttpClient$Redirect/ALWAYS)
        :normal (.followRedirects
-                builder
-                java.net.http.HttpClient$Redirect/NORMAL))
+                 builder
+                 java.net.http.HttpClient$Redirect/NORMAL))
      (.build builder))))
 
 ;; Request Building

--- a/components/http-client/test/mcp_clj/http_client/core_test.clj
+++ b/components/http-client/test/mcp_clj/http_client/core_test.clj
@@ -1,7 +1,7 @@
 (ns mcp-clj.http-client.core-test
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [mcp-clj.http-client.core :as http-client]))
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.http-client.core :as http-client]))
 
 (deftest create-client-test
   ;; Test basic HTTP client creation functionality

--- a/components/json-rpc/src/mcp_clj/json_rpc/http_client.clj
+++ b/components/json-rpc/src/mcp_clj/json_rpc/http_client.clj
@@ -1,22 +1,22 @@
 (ns mcp-clj.json-rpc.http-client
   "JSON-RPC client for HTTP transport with SSE support"
   (:require
-   [clojure.data.json :as json]
-   [clojure.string :as str]
-   [mcp-clj.http-client.core :as http-client]
-   [mcp-clj.json-rpc.executor :as executor]
-   [mcp-clj.json-rpc.protocol :as protocol]
-   [mcp-clj.log :as log])
+    [clojure.data.json :as json]
+    [clojure.string :as str]
+    [mcp-clj.http-client.core :as http-client]
+    [mcp-clj.json-rpc.executor :as executor]
+    [mcp-clj.json-rpc.protocol :as protocol]
+    [mcp-clj.log :as log])
   (:import
-   (java.io
-    BufferedReader
-    InputStreamReader)
-   (java.net
-    URI)
-   (java.util.concurrent
-    CompletableFuture
-    ConcurrentHashMap
-    TimeUnit)))
+    (java.io
+      BufferedReader
+      InputStreamReader)
+    (java.net
+      URI)
+    (java.util.concurrent
+      CompletableFuture
+      ConcurrentHashMap
+      TimeUnit)))
 
 ;; Forward declarations
 (declare http-send-request! http-send-notification! close-http-json-rpc-client!)
@@ -24,14 +24,14 @@
 ;; HTTP JSON-RPC Client
 
 (defrecord HTTPJSONRPCClient
-           [base-url ; Base URL for the MCP server
-            session-id ; atom holding Session ID for this client
-            pending-requests ; ConcurrentHashMap of request-id -> CompletableFuture
-            request-id-counter ; atom for generating unique request IDs
-            executor ; executor for async operations
-            running ; atom for controlling SSE reader
-            sse-connection ; atom holding SSE connection details
-            notification-handler] ; function to handle notifications
+  [base-url ; Base URL for the MCP server
+   session-id ; atom holding Session ID for this client
+   pending-requests ; ConcurrentHashMap of request-id -> CompletableFuture
+   request-id-counter ; atom for generating unique request IDs
+   executor ; executor for async operations
+   running ; atom for controlling SSE reader
+   sse-connection ; atom holding SSE connection details
+   notification-handler] ; function to handle notifications
 
   protocol/JSONRPCClient
 
@@ -39,13 +39,16 @@
     [this method params timeout-ms]
     (http-send-request! this method params timeout-ms))
 
+
   (send-notification!
     [this method params]
     (http-send-notification! this method params))
 
+
   (close!
     [this]
     (close-http-json-rpc-client! this))
+
 
   (alive?
     [this]
@@ -169,14 +172,14 @@
   [{:keys [url session-id notification-handler num-threads]
     :or {num-threads 2}}]
   (let [client (->HTTPJSONRPCClient
-                url
-                (atom session-id)
-                (ConcurrentHashMap.)
-                (atom 0)
-                (executor/create-executor num-threads)
-                (atom true)
-                (atom nil)
-                notification-handler)]
+                 url
+                 (atom session-id)
+                 (ConcurrentHashMap.)
+                 (atom 0)
+                 (executor/create-executor num-threads)
+                 (atom true)
+                 (atom nil)
+                 notification-handler)]
     ;; Don't start SSE immediately - let it be established after first request with session
     client))
 
@@ -195,59 +198,59 @@
 
     ;; Send HTTP POST request
     (executor/submit!
-     (:executor client)
-     (fn []
-       (try
-         (log/debug :client/send "Send request" {:method method})
-         (let [url (str (:base-url client) "/")
-               headers (make-headers client)
-               response (http-client/http-post url
-                                               {:headers headers
-                                                :body (json/write-str request)
-                                                :content-type :json
-                                                :accept :json
-                                                :as :json
-                                                :throw-exceptions false})]
-           (log/debug :client/send
-                      {:msg "Receive response"
-                       :response response})
-           (if (= 200 (:status response))
-             (do
+      (:executor client)
+      (fn []
+        (try
+          (log/debug :client/send "Send request" {:method method})
+          (let [url (str (:base-url client) "/")
+                headers (make-headers client)
+                response (http-client/http-post url
+                                                {:headers headers
+                                                 :body (json/write-str request)
+                                                 :content-type :json
+                                                 :accept :json
+                                                 :as :json
+                                                 :throw-exceptions false})]
+            (log/debug :client/send
+                       {:msg "Receive response"
+                        :response response})
+            (if (= 200 (:status response))
+              (do
                 ;; Update session ID if provided
-               (when-let [new-session-id (get-in
-                                          response
-                                          [:headers "x-session-id"])]
-                 (when (not= new-session-id @(:session-id client))
-                   (log/info :http/session-updated {:old @(:session-id client)
-                                                    :new new-session-id})
+                (when-let [new-session-id (get-in
+                                            response
+                                            [:headers "x-session-id"])]
+                  (when (not= new-session-id @(:session-id client))
+                    (log/info :http/session-updated {:old @(:session-id client)
+                                                     :new new-session-id})
                     ;; Update client's session ID
-                   (reset! (:session-id client) new-session-id)
+                    (reset! (:session-id client) new-session-id)
                     ;; Start SSE with new session
-                   (when-not @(:sse-connection client)
-                     (start-sse-connection! client))))
+                    (when-not @(:sse-connection client)
+                      (start-sse-connection! client))))
 
                 ;; Process response
-               (.complete
-                future
-                (process-json-rpc-response
-                 client
-                 (json/read-str (:body response) :key-fn keyword))))
+                (.complete
+                  future
+                  (process-json-rpc-response
+                    client
+                    (json/read-str (:body response) :key-fn keyword))))
               ;; HTTP error
-             (let [error-msg (str "HTTP error: " (:status response) " - "
-                                  (or (:body response) ""))]
-               (log/error
-                :http/request-failed
-                {:status (:status response)
-                 :body (:body response)})
-               (.completeExceptionally
-                future
-                (ex-info
-                 error-msg
-                 {:status (:status response)
-                  :body (:body response)})))))
-         (catch Exception e
-           (log/error :http/request-error {:error e :method method})
-           (.completeExceptionally future e)))))
+              (let [error-msg (str "HTTP error: " (:status response) " - "
+                                   (or (:body response) ""))]
+                (log/error
+                  :http/request-failed
+                  {:status (:status response)
+                   :body (:body response)})
+                (.completeExceptionally
+                  future
+                  (ex-info
+                    error-msg
+                    {:status (:status response)
+                     :body (:body response)})))))
+          (catch Exception e
+            (log/error :http/request-error {:error e :method method})
+            (.completeExceptionally future e)))))
 
     ;; Set timeout
     (try

--- a/projects/client/deps.edn
+++ b/projects/client/deps.edn
@@ -1,0 +1,7 @@
+{:deps
+ {poly/client-transport {:local/root "../../components/client-transport"}
+  poly/http-client {:local/root "../../components/http-client"}
+  poly/json-rpc {:local/root "../../components/json-rpc"}
+  poly/log {:local/root "../../components/log"}
+  poly/mcp-client {:local/root "../../components/mcp-client"}
+  poly/mcp-server {:local/root "../../components/mcp-server"}}}


### PR DESCRIPTION
Creates a new project that aggregates the mcp-client component and its
dependencies into a deployable client jar. Includes all necessary
components: mcp-client, client-transport, json-rpc, http-client, log,
and mcp-server (for version information).