### PR TITLE
Add projects/java-sdk-wrapper for SDK interop component

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -99,7 +99,7 @@ Include REFINE to refine the spec
 - [x] add projects/client to build a client jar
         - include the mcp-client component
 
-- [ ] add projects/java-sdk-wrapper to build a jar with the SDK interop
+- [x] add projects/java-sdk-wrapper to build a jar with the SDK interop
       component
 
 - [ ] add a github action to run the tests

--- a/projects/java-sdk-wrapper/deps.edn
+++ b/projects/java-sdk-wrapper/deps.edn
@@ -1,0 +1,2 @@
+{:deps
+ {poly/interop {:local/root "../../components/interop"}}}


### PR DESCRIPTION
Creates a new project that packages the Java SDK interoperability
component into a distributable jar artifact.