### PR TITLE
refactor: extract versions into shared component

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -102,7 +102,14 @@ Include REFINE to refine the spec
 - [x] add projects/java-sdk-wrapper to build a jar with the SDK interop
       component
 
-- [ ] add a github action to run the tests
+- [x] add a github action to run the tests
+
+- [x] factor out the list of versions, and get-latest-version, from
+      mcp-clj.mcp-server.version into a new versions namespace in a new
+      polylith style component that can be used by both server and
+      client
+
+- [ ] merge mcp-clj.json-rpc.protocol and mcp-clj.json-rpc.protocols
 
 - [ ] extend the interop to enable use of SSE transport ? not sure this
       is worth doing still
@@ -154,6 +161,55 @@ Include REFINE to refine the spec
 	  - Tool response formatting (structured content support)
 	  - Comprehensive test coverage for all version-specific behaviors
 	  - Utility functions for version comparison and feature detection
+
+- [ ] Add a release workflow
+
+Release Process:
+
+Trigger: Use GitHub's workflow dispatch to start a release
+Build & Test: Runs full test suite and builds JAR
+Smoke Tests: Validates the built artifact works
+Changelog: Auto-generates changelog from git commits
+Tag & Push: Creates git tag and pushes to repository
+Deploy: Pushes to Clojars
+GitHub Release: Creates release with changelog and JAR attachment
+
+Key Features:
+
+Dry run option to test the pipeline without deploying
+Automatic changelog generation from git history
+Smoke testing of built artifacts before deployment
+Proper Maven metadata for Clojars compatibility
+Rollback safety - only tags and deploys after all tests pass
+
+Next Steps:
+
+Set up the Clojars account and get deploy tokens
+Add the secrets to your GitHub repository
+Customize the smoke tests for your specific project
+Test with a dry run first
+
+The workflow is designed to be safe - it won't deploy anything until all
+tests pass and artifacts are validated.
+
+- use deps.edn and tools.build
+- use Major.minor.commit-seq-num
+
+
+- [ ] add a ci check for reflection
+
+ Add reflection checking to GitHub Actions:
+  - name: Check for reflection warnings
+    run: |
+      clojure -M:dev -e "
+      (set! *warn-on-reflection* true)
+      (require 'poly.all-components :reload)" 2>&1 |
+      tee reflection-warnings.log
+
+      if grep -q "Reflection warning" reflection-warnings.log; then
+        echo "Reflection warnings found!"
+        exit 1
+      fi
 
 
 - [ ] proper capabilities handling

--- a/components/json-rpc/src/mcp_clj/json_rpc/executor.clj
+++ b/components/json-rpc/src/mcp_clj/json_rpc/executor.clj
@@ -7,12 +7,9 @@
       Callable
       ExecutorService
       Executors
-      RejectedExecutionException
       ScheduledExecutorService
       ThreadPoolExecutor
       TimeUnit)))
-
-(def ^:private default-request-timeout-ms 30000)
 
 (defn- wrap-log-throwables
   "Wrap a function to log any exceptions"

--- a/components/json-rpc/src/mcp_clj/json_rpc/http_client.clj
+++ b/components/json-rpc/src/mcp_clj/json_rpc/http_client.clj
@@ -2,7 +2,6 @@
   "JSON-RPC client for HTTP transport with SSE support"
   (:require
    [clojure.data.json :as json]
-   [clojure.java.io :as io]
    [clojure.string :as str]
    [mcp-clj.http-client.core :as http-client]
    [mcp-clj.json-rpc.executor :as executor]

--- a/components/json-rpc/src/mcp_clj/json_rpc/http_server.clj
+++ b/components/json-rpc/src/mcp_clj/json_rpc/http_server.clj
@@ -9,14 +9,7 @@
     [mcp-clj.json-rpc.json-protocol :as json-protocol]
     [mcp-clj.json-rpc.protocols :as protocols]
     [mcp-clj.log :as log]
-    [mcp-clj.sse :as sse])
-  (:import
-    (java.util.concurrent
-      RejectedExecutionException)))
-
-;; Configuration
-
-(def ^:private request-timeout-ms 30000)
+    [mcp-clj.sse :as sse]))
 
 ;; Session Management
 

--- a/components/mcp-client/deps.edn
+++ b/components/mcp-client/deps.edn
@@ -1,6 +1,7 @@
 {:deps {poly/client-transport {:local/root "../client-transport"}
         poly/json-rpc         {:local/root "../json-rpc"}
-        poly/log              {:local/root "../log"}}
+        poly/log              {:local/root "../log"}
+        poly/versions         {:local/root "../versions"}}
 
  :aliases
  {:dev {:extra-deps {org.clojure/tools.namespace {:mvn/version "1.3.0"}}}

--- a/components/mcp-client/src/mcp_clj/mcp_client/core.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/core.clj
@@ -7,7 +7,7 @@
     [mcp-clj.mcp-client.session :as session]
     [mcp-clj.mcp-client.tools :as tools]
     [mcp-clj.mcp-client.transport :as transport]
-    [mcp-clj.mcp-server.version :as version])
+    [mcp-clj.versions :as version])
   (:import
     (java.lang
       AutoCloseable)

--- a/components/mcp-server/deps.edn
+++ b/components/mcp-server/deps.edn
@@ -2,7 +2,8 @@
  :deps  {org.clojure/clojure   {:mvn/version "1.12.0"}
          poly/json-rpc         {:local/root "../json-rpc"}
          poly/tools            {:local/root "../tools"}
-         poly/server-transport {:local/root "../server-transport"}}
+         poly/server-transport {:local/root "../server-transport"}
+         poly/versions         {:local/root "../versions"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {poly/interop {:local/root "../interop"}

--- a/components/mcp-server/src/mcp_clj/mcp_server/version.clj
+++ b/components/mcp-server/src/mcp_clj/mcp_server/version.clj
@@ -1,19 +1,6 @@
 (ns mcp-clj.mcp-server.version
-  "MCP protocol version negotiation utilities")
-
-(def ^:private supported-versions
-  "Supported MCP protocol versions in descending order (newest first)"
-  ["2025-06-18" "2025-03-26" "2024-11-05"])
-
-(defn get-latest-version
-  "Get the latest supported protocol version"
-  []
-  (first supported-versions))
-
-(defn supported?
-  "Check if a protocol version is supported"
-  [version]
-  (boolean (some #{version} supported-versions)))
+  "MCP protocol version negotiation utilities"
+  (:require [mcp-clj.versions :as versions]))
 
 (defn negotiate-version
   "Negotiate protocol version according to MCP specification.
@@ -31,17 +18,17 @@
     - :client-was-supported? - Whether the client's version was supported
     - :supported-versions - List of all supported versions"
   [client-requested-version]
-  (let [client-supported?  (supported? client-requested-version)
+  (let [client-supported?  (versions/supported? client-requested-version)
         negotiated-version (if client-supported?
                              client-requested-version
                              ;; Find the highest version supported by both. For
                              ;; now, we assume client supports standard versions
                              ;; In a real implementation, we'd need client's
                              ;; supported versions
-                             (get-latest-version))]
+                             (versions/get-latest-version))]
     {:negotiated-version    negotiated-version
      :client-was-supported? client-supported?
-     :supported-versions    supported-versions}))
+     :supported-versions    versions/supported-versions}))
 
 ;; Version comparison utilities
 

--- a/components/mcp-server/test/mcp_clj/mcp_server/version_test.clj
+++ b/components/mcp-server/test/mcp_clj/mcp_server/version_test.clj
@@ -1,7 +1,8 @@
 (ns mcp-clj.mcp-server.version-test
   (:require
     [clojure.test :refer [deftest is testing]]
-    [mcp-clj.mcp-server.version :as version]))
+    [mcp-clj.mcp-server.version :as version]
+    [mcp-clj.versions :as versions]))
 
 (deftest negotiate-version-test
   (testing "version negotiation according to MCP specification"
@@ -38,14 +39,14 @@
 
 (deftest supported?-test
   (testing "version support checking"
-    (is (true? (version/supported? "2025-06-18")))
-    (is (true? (version/supported? "2024-11-05")))
-    (is (false? (version/supported? "2024-01-01")))
-    (is (false? (version/supported? "0.2")))))
+    (is (true? (versions/supported? "2025-06-18")))
+    (is (true? (versions/supported? "2024-11-05")))
+    (is (false? (versions/supported? "2024-01-01")))
+    (is (false? (versions/supported? "0.2")))))
 
 (deftest get-latest-version-test
   (testing "latest version retrieval"
-    (is (= "2025-06-18" (version/get-latest-version)))))
+    (is (= "2025-06-18" (versions/get-latest-version)))))
 
 (deftest version-specific-behavior-test
   (testing "version-specific behavior dispatch"

--- a/components/versions/deps.edn
+++ b/components/versions/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {}}}}

--- a/components/versions/src/mcp_clj/versions.clj
+++ b/components/versions/src/mcp_clj/versions.clj
@@ -1,0 +1,16 @@
+(ns mcp-clj.versions
+  "MCP protocol version management utilities")
+
+(def supported-versions
+  "Supported MCP protocol versions in descending order (newest first)"
+  ["2025-06-18" "2025-03-26" "2024-11-05"])
+
+(defn get-latest-version
+  "Get the latest supported protocol version"
+  []
+  (first supported-versions))
+
+(defn supported?
+  "Check if a protocol version is supported"
+  [version]
+  (boolean (some #{version} supported-versions)))

--- a/components/versions/test/mcp_clj/versions_test.clj
+++ b/components/versions/test/mcp_clj/versions_test.clj
@@ -1,0 +1,24 @@
+(ns mcp-clj.versions-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.versions :as versions]))
+
+(deftest versions-test
+  ;; Test that supported-versions returns versions as strings in descending order
+  (testing "supported-versions has expected format and order"
+    (is (vector? versions/supported-versions))
+    (is (every? string? versions/supported-versions))
+    ;; Verify order is descending (newest first)
+    (is (= ["2025-06-18" "2025-03-26" "2024-11-05"] versions/supported-versions)))
+
+  (testing "get-latest-version returns the first supported version"
+    (is (= "2025-06-18" (versions/get-latest-version)))
+    (is (= (first versions/supported-versions) (versions/get-latest-version))))
+
+  (testing "supported? correctly identifies supported versions"
+    (is (true? (versions/supported? "2025-06-18")))
+    (is (true? (versions/supported? "2025-03-26")))
+    (is (true? (versions/supported? "2024-11-05")))
+    (is (false? (versions/supported? "2023-01-01")))
+    (is (false? (versions/supported? "invalid-version")))
+    (is (false? (versions/supported? nil)))))

--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,8 @@
                  "components/log/test"
                  "components/mcp-client/test"
                  "components/mcp-server/test"
-                 "components/tools/test"]
+                 "components/tools/test"
+                 "components/versions/test"]
    :extra-deps
    {poly/client-transport         {:local/root "components/client-transport"}
     poly/http                     {:local/root "components/http"}
@@ -24,6 +25,7 @@
     poly/mcp-server               {:local/root "components/mcp-server"}
     poly/server-transport         {:local/root "components/server-transport"}
     poly/tools                    {:local/root "components/tools"}
+    poly/versions                 {:local/root "components/versions"}
     lambdaisland/kaocha           {:mvn/version "1.87.1366"}
     lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
     org.clojure/clojure           {:mvn/version "1.12.0"}}
@@ -40,7 +42,8 @@
                          "components/log/test"
                          "components/mcp-client/test"
                          "components/mcp-server/test"
-                         "components/tools/test"]
+                         "components/tools/test"
+                         "components/versions/test"]
            :extra-deps
            {org.clojure/test.check                         {:mvn/version "1.1.1"}
             org.clojure/clojure                            {:mvn/version "1.12.0"}
@@ -48,6 +51,7 @@
             poly/in-memory-transport                       {:local/root "components/in-memory-transport"}
             poly/interop                                   {:local/root "components/interop"}
             poly/server-transport                          {:local/root "components/server-transport"}
+            poly/versions                                  {:local/root "components/versions"}
             ;; MCP Java SDK for cross-implementation testing
             io.modelcontextprotocol.sdk/mcp                {:mvn/version "0.11.2"}
             ;; MCP Java SDK Spring WebFlux support for HTTP transport
@@ -63,6 +67,7 @@
             poly/in-memory-transport      {:local/root "components/in-memory-transport"}
             poly/interop                  {:local/root "components/interop"}
             poly/server-transport         {:local/root "components/server-transport"}
+            poly/versions                 {:local/root "components/versions"}
             hato/hato                     {:mvn/version "1.0.0"}}
            :exec-fn   kaocha.runner/exec-fn
            :exec-args {}

--- a/tests.edn
+++ b/tests.edn
@@ -13,7 +13,8 @@
                           "components/mcp-client/src"
                           "components/mcp-server/src"
                           "components/stdio-server/src"
-                          "components/tools/src"]
+                          "components/tools/src"
+                          "components/versions/src"]
            :test-paths ["components/client-transport/test"
                         "components/http-client/test"
                         "components/http-server/test"
@@ -23,7 +24,8 @@
                         "components/mcp-client/test"
                         "components/mcp-server/test"
                         "components/stdio-server/test"
-                        "components/tools/test"]
+                        "components/tools/test"
+                        "components/versions/test"]
            :skip-meta [:very-slow :integ]}
 
           {:kaocha.testable/id :integration
@@ -39,7 +41,8 @@
                           "components/mcp-client/src"
                           "components/mcp-server/src"
                           "components/stdio-server/src"
-                          "components/tools/src"]
+                          "components/tools/src"
+                          "components/versions/src"]
            :test-paths ["components/client-transport/test"
                         "components/http-server/test"
                         "components/in-memory-transport/test"
@@ -48,7 +51,8 @@
                         "components/mcp-client/test"
                         "components/mcp-server/test"
                         "components/stdio-server/test"
-                        "components/tools/test"]
+                        "components/tools/test"
+                        "components/versions/test"]
            :kaocha.filter/focus-meta [:integ]}]
 
   :plugins [:kaocha.plugin/randomize


### PR DESCRIPTION
- Create new versions polylith component with shared version management
- Move supported-versions, get-latest-version, and supported? functions
  from mcp-clj.mcp-server.version to mcp-clj.versions
- Update mcp-server and mcp-client components to use new versions component
- Remove inappropriate dependency where client imported from server namespace
- Add comprehensive tests for versions component
- Update project configuration to include versions component in builds and tests