### PR TITLE
Add client-side prompts support

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -111,6 +111,11 @@ Include REFINE to refine the spec
 
 - [x] merge mcp-clj.json-rpc.protocol and mcp-clj.json-rpc.protocols
 
+- [x] add mcp-client support for prompts, similar to the support for
+      tools.
+	  server functions:
+      https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-06-18/server/prompts.mdx
+
 - [ ] extend the interop to enable use of SSE transport ? not sure this
       is worth doing still
 

--- a/components/mcp-client/src/mcp_clj/mcp_client/core.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/core.clj
@@ -4,6 +4,7 @@
     [mcp-clj.client-transport.factory :as transport-factory]
     [mcp-clj.client-transport.protocol :as transport-protocol]
     [mcp-clj.log :as log]
+    [mcp-clj.mcp-client.prompts :as prompts]
     [mcp-clj.mcp-client.session :as session]
     [mcp-clj.mcp-client.tools :as tools]
     [mcp-clj.mcp-client.transport :as transport]
@@ -238,3 +239,38 @@
   Uses cached tools if available, otherwise queries the server."
   [client]
   (tools/available-tools?-impl client))
+
+;; Prompt Calling API
+
+(defn list-prompts
+  "Discover available prompts from the server.
+
+  Returns a CompletableFuture that will contain a map with :prompts key
+  containing vector of prompt definitions. Each prompt has :name, :description,
+  and :arguments.
+
+  Supports pagination with optional options map containing :cursor."
+  ([client]
+   (prompts/list-prompts-impl client))
+  ([client options]
+   (prompts/list-prompts-impl client options)))
+
+(defn get-prompt
+  "Get a specific prompt with optional arguments for templating.
+
+  Returns a CompletableFuture that will contain the prompt result on success.
+  The future will complete exceptionally on error.
+
+  Arguments are used for template substitution in prompt messages."
+  ([client prompt-name]
+   (prompts/get-prompt-impl client prompt-name))
+  ([client prompt-name arguments]
+   (prompts/get-prompt-impl client prompt-name arguments)))
+
+(defn available-prompts?
+  "Check if any prompts are available from the server.
+
+  Returns true if prompts are available, false otherwise.
+  Uses cached prompts if available, otherwise queries the server."
+  [client]
+  (prompts/available-prompts?-impl client))

--- a/components/mcp-client/src/mcp_clj/mcp_client/prompts.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/prompts.clj
@@ -1,0 +1,130 @@
+(ns mcp-clj.mcp-client.prompts
+  "Prompt calling implementation for MCP client"
+  (:require
+    [mcp-clj.log :as log]
+    [mcp-clj.mcp-client.transport :as transport])
+  (:import
+    (java.util.concurrent
+      CompletableFuture)))
+
+(defn- get-prompts-cache
+  "Get or create prompts cache in client session"
+  [client]
+  (let [session-atom (:session client)]
+    (or (:prompts-cache @session-atom)
+        (let [cache (atom nil)]
+          (swap! session-atom assoc :prompts-cache cache)
+          cache))))
+
+(defn- cache-prompts!
+  "Cache discovered prompts in client session"
+  [client prompts]
+  (let [cache (get-prompts-cache client)]
+    (reset! cache prompts)
+    prompts))
+
+(defn- get-cached-prompts
+  "Get cached prompts from client session"
+  [client]
+  @(get-prompts-cache client))
+
+(defn list-prompts-impl
+  "Discover available prompts from the server.
+
+  Returns a CompletableFuture that will contain a map with :prompts key
+  containing vector of prompt definitions. Each prompt
+  has :name, :description, and :arguments.
+
+  Supports pagination with optional :cursor parameter."
+  ^CompletableFuture [client & [{:keys [cursor]}]]
+  (try
+    (let [transport (:transport client)
+          params    (cond-> {}
+                      cursor (assoc :cursor cursor))
+          response  (transport/send-request!
+                      transport
+                      "prompts/list"
+                      params
+                      30000)]
+      ;; Transform the response future to handle caching and return prompts
+      (.thenApply response
+                  (reify java.util.function.Function
+                    (apply
+                      [_ result]
+                      (if-let [prompts (:prompts result)]
+                        (do
+                          (when-not cursor ; Only cache first page
+                            (cache-prompts! client prompts))
+                          (cond-> {:prompts prompts}
+                            (:nextCursor result)
+                            (assoc :nextCursor (:nextCursor result))))
+                        {:prompts []})))))
+    (catch Exception e
+      (log/error :client/list-prompts-error {:error (.getMessage e)})
+      ;; Return a failed future for immediate exceptions
+      (java.util.concurrent.CompletableFuture/failedFuture e))))
+
+(defn get-prompt-impl
+  "Get a specific prompt with optional arguments.
+
+  Returns a CompletableFuture that will contain the prompt result on success.
+  For errors, the future contains a map with :isError true.
+
+  The prompt name is required, arguments are optional for templating."
+  ^CompletableFuture [client prompt-name & [arguments]]
+  (log/info :client/get-prompt-start {:prompt-name prompt-name})
+  (try
+    (let [transport (:transport client)
+          params    (cond-> {:name prompt-name}
+                      arguments (assoc :arguments arguments))]
+      (.thenApply
+        (transport/send-request!
+          transport
+          "prompts/get"
+          params
+          30000)
+        (reify java.util.function.Function
+          (apply
+            [_ result]
+            (let [is-error (:isError result false)]
+              (if is-error
+                (do
+                  (log/error :client/get-prompt-error
+                             {:prompt-name prompt-name
+                              :content     (:content result)})
+                  ;; Return error map instead of throwing
+                  {:isError     true
+                   :prompt-name prompt-name
+                   :content     (:content result)})
+                (do
+                  (log/info :client/get-prompt-success
+                            {:prompt-name prompt-name})
+                  ;; Return the prompt result
+                  result)))))))
+    (catch Exception e
+      ;; Return a failed future for immediate exceptions (like transport errors)
+      (log/error :client/get-prompt-error {:prompt-name prompt-name
+                                           :error       (.getMessage e)
+                                           :ex          e})
+      (CompletableFuture/failedFuture
+        (ex-info
+          (str "Prompt request failed: " prompt-name)
+          {:prompt-name prompt-name
+           :error       (.getMessage e)}
+          e)))))
+
+(defn available-prompts?-impl
+  "Check if any prompts are available from the server.
+
+  Returns true if prompts are available, false otherwise.
+  Uses cached prompts if available, otherwise queries the server."
+  [client]
+  (try
+    (if-let [cached-prompts (get-cached-prompts client)]
+      (boolean (seq cached-prompts))
+      (when-let [result-future (list-prompts-impl client)]
+        (let [result @result-future]
+          (boolean (seq (:prompts result))))))
+    (catch Exception e
+      (log/debug :client/available-prompts-error {:error (.getMessage e)})
+      false)))

--- a/components/mcp-client/test/mcp_clj/mcp_client/prompts_integration_test.clj
+++ b/components/mcp-client/test/mcp_clj/mcp_client/prompts_integration_test.clj
@@ -1,0 +1,164 @@
+(ns mcp-clj.mcp-client.prompts-integration-test
+  "Integration tests for MCP client prompts functionality using real MCP server"
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.mcp-client.core :as client]
+    [mcp-clj.mcp-client.prompts :as prompts]))
+
+(deftest ^:integ prompts-list-integration-test
+  (testing "MCP client can list prompts from real MCP server"
+    (with-open [client (client/create-client
+                         {:transport    {:type    :stdio
+                                         :command "clojure"
+                                         :args    ["-M:stdio-server"]}
+                          :client-info  {:name    "prompts-list-integration-test"
+                                         :version "1.0.0"}
+                          :capabilities {}})]
+
+      ;; Wait for client to initialize
+      (client/wait-for-ready client 20000)
+      (is (client/client-ready? client))
+
+      (testing "can list available prompts"
+        (let [future (prompts/list-prompts-impl client)
+              result @future]
+          (is (map? result))
+          (is (contains? result :prompts))
+          (is (vector? (:prompts result)))
+          (is (seq (:prompts result))) ; Should have at least the built-in repl prompt
+
+          ;; Check that we get the built-in repl prompt
+          (let [prompt-names (set (map :name (:prompts result)))]
+            (is (contains? prompt-names "repl"))
+
+            ;; Find the repl prompt and check its structure
+            (let [repl-prompt (first (filter #(= "repl" (:name %)) (:prompts result)))]
+              (is (some? repl-prompt))
+              (is (= "repl" (:name repl-prompt)))
+              (is (string? (:description repl-prompt)))
+              (is (vector? (:arguments repl-prompt)))
+              (is (seq (:arguments repl-prompt))) ; Should have the code argument
+
+              ;; Check the code argument structure
+              (let [code-arg (first (filter #(= "code" (:name %)) (:arguments repl-prompt)))]
+                (is (some? code-arg))
+                (is (= "code" (:name code-arg)))
+                (is (string? (:description code-arg))))))))
+
+      (testing "available-prompts? returns true"
+        (is (true? (prompts/available-prompts?-impl client)))))))
+
+(deftest ^:integ prompts-get-integration-test
+  (testing "MCP client can get specific prompts from real MCP server"
+    (with-open [client (client/create-client
+                         {:transport    {:type    :stdio
+                                         :command "clojure"
+                                         :args    ["-M:stdio-server"]}
+                          :client-info  {:name    "prompts-get-integration-test"
+                                         :version "1.0.0"}
+                          :capabilities {}})]
+
+      ;; Wait for client to initialize
+      (client/wait-for-ready client 20000)
+      (is (client/client-ready? client))
+
+      (testing "can get repl prompt without arguments"
+        (let [future (prompts/get-prompt-impl client "repl")
+              result @future]
+          (is (map? result))
+          (is (not (:isError result false)))
+          (is (string? (:description result)))
+          (is (vector? (:messages result)))
+          (is (seq (:messages result))) ; Should have messages
+
+          ;; Check message structure
+          (let [messages (:messages result)]
+            (is (>= (count messages) 1)) ; Should have at least one message
+
+            ;; Check first message is system message
+            (let [first-msg (first messages)]
+              (is (= "system" (:role first-msg)))
+              (is (map? (:content first-msg)))
+              (is (= "text" (:type (:content first-msg))))
+              (is (string? (:text (:content first-msg))))
+              (is (re-find #"REPL" (:text (:content first-msg)))))
+
+            ;; Check there's a user message with template
+            (let [user-msgs (filter #(= "user" (:role %)) messages)]
+              (is (seq user-msgs))
+              (let [user-msg (first user-msgs)]
+                (is (= "user" (:role user-msg)))
+                (is (string? (get-in user-msg [:content :text])))
+                (is (re-find #"\{\{code\}\}" (get-in user-msg [:content :text]))))))))
+
+      (testing "can get repl prompt with code argument"
+        (let [future (prompts/get-prompt-impl client "repl" {"code" "(+ 1 2)"})
+              result @future]
+          (is (map? result))
+          (is (not (:isError result false)))
+          (is (string? (:description result)))
+          (is (vector? (:messages result)))
+
+          ;; Check that template substitution occurred
+          (let [messages (:messages result)
+                user-msgs (filter #(= "user" (:role %)) messages)]
+            (is (seq user-msgs))
+            (let [user-msg (first user-msgs)
+                  text (get-in user-msg [:content :text])]
+              (is (string? text))
+              (is (re-find #"\(\+ 1 2\)" text))
+              (is (not (re-find #"\{\{code\}\}" text))))))) ; Template should be replaced
+
+      (testing "handles non-existent prompt gracefully"
+        (let [future (prompts/get-prompt-impl client "non-existent-prompt")
+              result @future]
+          (is (map? result))
+          (is (:isError result))
+          (is (= "non-existent-prompt" (:prompt-name result)))
+          (is (vector? (:content result)))
+          (let [error-content (first (:content result))]
+            (is (= "text" (:type error-content)))
+            (is (re-find #"not found" (:text error-content)))))))))
+
+(deftest ^:integ prompts-public-api-integration-test
+  (testing "MCP client public API for prompts works with real server"
+    (with-open [client (client/create-client
+                         {:transport    {:type    :stdio
+                                         :command "clojure"
+                                         :args    ["-M:stdio-server"]}
+                          :client-info  {:name    "prompts-api-integration-test"
+                                         :version "1.0.0"}
+                          :capabilities {}})]
+
+      ;; Wait for client to initialize
+      (client/wait-for-ready client 20000)
+      (is (client/client-ready? client))
+
+      (testing "public list-prompts function works"
+        (let [future (client/list-prompts client)
+              result @future]
+          (is (map? result))
+          (is (vector? (:prompts result)))
+          (is (seq (:prompts result)))))
+
+      (testing "public get-prompt function works without arguments"
+        (let [future (client/get-prompt client "repl")
+              result @future]
+          (is (map? result))
+          (is (not (:isError result false)))
+          (is (vector? (:messages result)))))
+
+      (testing "public get-prompt function works with arguments"
+        (let [future (client/get-prompt client "repl" {"code" "(println \"hello\")"})
+              result @future]
+          (is (map? result))
+          (is (not (:isError result false)))
+          (is (vector? (:messages result)))
+          ;; Check template substitution
+          (let [user-msgs (filter #(= "user" (:role %)) (:messages result))]
+            (is (seq user-msgs))
+            (let [text (get-in (first user-msgs) [:content :text])]
+              (is (re-find #"println" text))))))
+
+      (testing "public available-prompts? function works"
+        (is (true? (client/available-prompts? client)))))))

--- a/components/mcp-client/test/mcp_clj/mcp_client/prompts_test.clj
+++ b/components/mcp-client/test/mcp_clj/mcp_client/prompts_test.clj
@@ -1,0 +1,242 @@
+(ns mcp-clj.mcp-client.prompts-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.client-transport.factory :as client-transport-factory]
+    [mcp-clj.in-memory-transport.shared :as shared]
+    [mcp-clj.mcp-client.prompts :as prompts]
+    [mcp-clj.server-transport.factory :as server-transport-factory])
+  (:import
+    (java.util.concurrent
+      CompletableFuture
+      TimeUnit)))
+
+;; Transport registration function for robust test isolation
+(defn ensure-in-memory-transport-registered!
+  "Ensure in-memory transport is registered in both client and server factories.
+  Can be called multiple times safely - registration is idempotent."
+  []
+  (client-transport-factory/register-transport!
+    :in-memory
+    (fn [options]
+      (require 'mcp-clj.in-memory-transport.client)
+      (let [create-fn (ns-resolve
+                        'mcp-clj.in-memory-transport.client
+                        'create-transport)]
+        (create-fn options))))
+  (server-transport-factory/register-transport!
+    :in-memory
+    (fn [options handlers]
+      (require 'mcp-clj.in-memory-transport.server)
+      (let [create-server (ns-resolve
+                            'mcp-clj.in-memory-transport.server
+                            'create-in-memory-server)]
+        (create-server options handlers)))))
+
+;; Ensure transport is registered at namespace load time
+(ensure-in-memory-transport-registered!)
+
+(defn- stop-server!
+  "Stop an in-memory server using lazy-loaded function"
+  [server]
+  (require 'mcp-clj.in-memory-transport.server)
+  ((ns-resolve 'mcp-clj.in-memory-transport.server 'stop!) server))
+
+(defn- create-test-client-with-handler
+  "Create a test client with in-memory transport and custom handler"
+  [handler]
+  ;; Ensure transport is registered before creating client/server
+  (ensure-in-memory-transport-registered!)
+  (let [shared-transport (shared/create-shared-transport)
+        session (atom {})
+        transport ((:create-client-transport shared-transport)
+                   {:shared-transport shared-transport})
+        server ((:create-server-transport shared-transport)
+                {:shared-transport shared-transport}
+                handler)
+        client {:transport transport
+                :session session}]
+    {:client client
+     :server server
+     :stop-fn #(stop-server! server)}))
+
+(deftest test-list-prompts-success
+  (testing "list-prompts-impl returns available prompts"
+    (let [mock-prompts [{:name "test-prompt"
+                         :description "A test prompt"
+                         :arguments [{:name "input" :description "Test input"}]}
+                        {:name "another-prompt"
+                         :description "Another test prompt"}]
+          handler (fn [method _params]
+                    (case method
+                      "prompts/list" {:prompts mock-prompts}
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (prompts/list-prompts-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= mock-prompts (:prompts result)))
+          (is (= 2 (count (:prompts result)))))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-list-prompts-with-pagination
+  (testing "list-prompts-impl handles pagination correctly"
+    (let [handler (fn [method params]
+                    (case method
+                      "prompts/list"
+                      (if (:cursor params)
+                        {:prompts [{:name "page2-prompt"}]}
+                        {:prompts [{:name "page1-prompt"}]
+                         :nextCursor "page2"})
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        ;; Test first page
+        (let [result-future (prompts/list-prompts-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [{:name "page1-prompt"}] (:prompts result)))
+          (is (= "page2" (:nextCursor result))))
+
+        ;; Test second page with cursor
+        (let [result-future (prompts/list-prompts-impl client {:cursor "page2"})
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [{:name "page2-prompt"}] (:prompts result)))
+          (is (nil? (:nextCursor result))))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-get-prompt-success
+  (testing "get-prompt-impl returns specific prompt"
+    (let [mock-prompt {:description "Test prompt description"
+                       :messages [{:role "user"
+                                   :content {:type "text"
+                                             :text "Please help with {{task}}"}}]}
+          handler (fn [method params]
+                    (case method
+                      "prompts/get"
+                      (if (= "test-prompt" (:name params))
+                        mock-prompt
+                        {:content [{:type "text" :text "Prompt not found"}]
+                         :isError true})
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (prompts/get-prompt-impl client "test-prompt")
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= mock-prompt result))
+          (is (= "Test prompt description" (:description result)))
+          (is (= 1 (count (:messages result)))))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-get-prompt-with-arguments
+  (testing "get-prompt-impl passes arguments for templating"
+    (let [handler (fn [method params]
+                    (case method
+                      "prompts/get"
+                      (if (and (= "test-prompt" (:name params))
+                               (:arguments params))
+                        {:description "Test prompt with args"
+                         :messages [{:role "user"
+                                     :content {:type "text"
+                                               :text "Task: coding"}}]}
+                        {:content [{:type "text" :text "Missing arguments"}]
+                         :isError true})
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (prompts/get-prompt-impl client "test-prompt" {:task "coding"})
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= "Test prompt with args" (:description result)))
+          (is (= "Task: coding" (get-in result [:messages 0 :content :text]))))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-get-prompt-error
+  (testing "get-prompt-impl handles errors gracefully"
+    (let [handler (fn [method _params]
+                    (case method
+                      "prompts/get" {:content [{:type "text" :text "Prompt not found"}]
+                                     :isError true}
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (prompts/get-prompt-impl client "nonexistent")
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (:isError result))
+          (is (= "nonexistent" (:prompt-name result)))
+          (is (= [{:type "text" :text "Prompt not found"}] (:content result))))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-available-prompts-with-cache
+  (testing "available-prompts?-impl uses cached prompts when available"
+    (let [mock-prompts [{:name "test-prompt"}]
+          handler (fn [method _params]
+                    (case method
+                      "prompts/list" {:prompts mock-prompts}
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        ;; First call should query server and cache results
+        (let [result-future (prompts/list-prompts-impl client)]
+          (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS))
+
+        ;; Now available-prompts? should use cache
+        (is (true? (prompts/available-prompts?-impl client)))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-available-prompts-no-cache
+  (testing "available-prompts?-impl queries server when no cache"
+    (let [mock-prompts [{:name "test-prompt"}]
+          handler (fn [method _params]
+                    (case method
+                      "prompts/list" {:prompts mock-prompts}
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        ;; Should query server directly
+        (is (true? (prompts/available-prompts?-impl client)))
+
+        (finally
+          (stop-fn))))))
+
+(deftest test-empty-prompts-list
+  (testing "list-prompts-impl handles empty prompts list"
+    (let [handler (fn [method _params]
+                    (case method
+                      "prompts/list" {:prompts []}
+                      nil))
+          {:keys [client stop-fn]} (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (prompts/list-prompts-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [] (:prompts result))))
+
+        ;; Available prompts should return false
+        (is (false? (prompts/available-prompts?-impl client)))
+
+        (finally
+          (stop-fn))))))


### PR DESCRIPTION
- New mcp-client/prompts.clj with implementation functions:
  - list-prompts-impl: discover available prompts with pagination
  - get-prompt-impl: get specific prompt with template arguments
  - available-prompts?-impl: check prompt availability with caching

- Updated mcp-client/core.clj with public API:
  - list-prompts: CompletableFuture-based prompt listing
  - get-prompt: prompt retrieval with templating support
  - available-prompts?: availability check with caching

Follows MCP 2025-06-18 specification for prompts/list and
prompts/get methods. Implements session caching, async patterns,
and error handling consistent with existing tools implementation.