### PR TITLE
feat: Add mcp-client support for resources

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -116,7 +116,7 @@ Include REFINE to refine the spec
 	  server functions:
       https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-06-18/server/prompts.mdx
 
-- [ ] add mcp-client support for resources, similar to the support for
+- [x] add mcp-client support for resources, similar to the support for
       tools and prompts.
 	  server functions:
 	  https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-06-18/server/resources.mdx

--- a/components/mcp-client/src/mcp_clj/mcp_client/core.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/core.clj
@@ -5,6 +5,7 @@
     [mcp-clj.client-transport.protocol :as transport-protocol]
     [mcp-clj.log :as log]
     [mcp-clj.mcp-client.prompts :as prompts]
+    [mcp-clj.mcp-client.resources :as resources]
     [mcp-clj.mcp-client.session :as session]
     [mcp-clj.mcp-client.tools :as tools]
     [mcp-clj.mcp-client.transport :as transport]
@@ -274,3 +275,36 @@
   Uses cached prompts if available, otherwise queries the server."
   [client]
   (prompts/available-prompts?-impl client))
+
+;; Resource API
+
+(defn list-resources
+  "Discover available resources from the server.
+
+  Returns a CompletableFuture that will contain a map with :resources key
+  containing vector of resource definitions. Each resource has :uri, :name,
+  and optional :title, :description, :mimeType, :size, :annotations.
+
+  Supports pagination with optional options map containing :cursor."
+  ([client]
+   (resources/list-resources-impl client))
+  ([client options]
+   (resources/list-resources-impl client options)))
+
+(defn read-resource
+  "Read a specific resource by URI.
+
+  Returns a CompletableFuture that will contain the resource content on success.
+  The future will complete exceptionally on error.
+
+  Content can be text (with :text field) or binary (with :blob field containing base64)."
+  [client resource-uri]
+  (resources/read-resource-impl client resource-uri))
+
+(defn available-resources?
+  "Check if any resources are available from the server.
+
+  Returns true if resources are available, false otherwise.
+  Uses cached resources if available, otherwise queries the server."
+  [client]
+  (resources/available-resources?-impl client))

--- a/components/mcp-client/test/mcp_clj/mcp_client/resources_integration_test.clj
+++ b/components/mcp-client/test/mcp_clj/mcp_client/resources_integration_test.clj
@@ -1,0 +1,177 @@
+(ns ^:integ mcp-clj.mcp-client.resources-integration-test
+  "Integration tests for resource functionality using full client setup"
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.client-transport.factory :as client-transport-factory]
+    [mcp-clj.in-memory-transport.shared :as shared]
+    [mcp-clj.mcp-client.core :as client]
+    [mcp-clj.server-transport.factory :as server-transport-factory])
+  (:import
+    (java.util.concurrent
+      CompletableFuture
+      TimeUnit)))
+
+;; Transport registration function for robust test isolation
+(defn ensure-in-memory-transport-registered!
+  "Ensure in-memory transport is registered in both client and server factories.
+  Can be called multiple times safely - registration is idempotent."
+  []
+  (client-transport-factory/register-transport!
+    :in-memory
+    (fn [options]
+      (require 'mcp-clj.in-memory-transport.client)
+      (let [create-fn (ns-resolve
+                        'mcp-clj.in-memory-transport.client
+                        'create-transport)]
+        (create-fn options))))
+  (server-transport-factory/register-transport!
+    :in-memory
+    (fn [options handlers]
+      (require 'mcp-clj.in-memory-transport.server)
+      (let [create-server (ns-resolve
+                            'mcp-clj.in-memory-transport.server
+                            'create-in-memory-server)]
+        (create-server options handlers)))))
+
+;; Ensure transport is registered at namespace load time
+(ensure-in-memory-transport-registered!)
+
+(defn- stop-server!
+  "Stop an in-memory server using lazy-loaded function"
+  [server]
+  (require 'mcp-clj.in-memory-transport.server)
+  ((ns-resolve 'mcp-clj.in-memory-transport.server 'stop!) server))
+
+(defn- create-test-server-with-resources
+  "Create a test server with resource handlers"
+  [shared-transport]
+  (let [mock-resources [{:uri "file:///readme.txt"
+                         :name "readme.txt"
+                         :description "Project readme file"
+                         :mimeType "text/plain"}
+                        {:uri "file:///config.json"
+                         :name "config.json"
+                         :description "Configuration file"}]
+        mock-content {"file:///readme.txt" {:contents [{:uri "file:///readme.txt"
+                                                        :text "# Project README\nWelcome to our project!"}]}
+                      "file:///config.json" {:contents [{:uri "file:///config.json"
+                                                         :text "{\"version\": \"1.0\", \"debug\": true}"}]}}
+        handlers {"initialize" (fn [_req _params]
+                                 {:protocolVersion "2025-06-18"
+                                  :capabilities {:resources {}}
+                                  :serverInfo {:name "test-server"
+                                               :version "1.0.0"}})
+                  "resources/list" (fn [_req params]
+                                     (if (:cursor params)
+                                       {:resources []}
+                                       {:resources mock-resources}))
+                  "resources/read" (fn [_req params]
+                                     (if-let [content (get mock-content (:uri params))]
+                                       content
+                                       {:content [{:type "text" :text "Resource not found"}]
+                                        :isError true}))}
+        create-server-fn (do
+                           (require 'mcp-clj.in-memory-transport.server)
+                           (ns-resolve
+                             'mcp-clj.in-memory-transport.server
+                             'create-in-memory-server))]
+    (create-server-fn {:shared shared-transport} handlers)))
+
+(deftest ^:integ test-client-resource-integration
+  (testing "full client integration with resources"
+    (ensure-in-memory-transport-registered!)
+    (let [shared-transport (shared/create-shared-transport)
+          server (create-test-server-with-resources shared-transport)
+          client-config {:transport {:type :in-memory
+                                     :shared shared-transport}
+                         :client-info {:name "test-client"
+                                       :version "1.0.0"}}
+          test-client (client/create-client client-config)]
+
+      (try
+        ;; Wait for client to initialize
+        (client/wait-for-ready test-client 5000)
+        (is (client/client-ready? test-client))
+
+        ;; Test resource availability
+        (is (client/available-resources? test-client))
+
+        ;; Test listing resources
+        (let [resources-future (client/list-resources test-client)
+              resources-result (.get ^CompletableFuture resources-future 5 TimeUnit/SECONDS)]
+          (is (= 2 (count (:resources resources-result))))
+          (is (some #(= "readme.txt" (:name %)) (:resources resources-result)))
+          (is (some #(= "config.json" (:name %)) (:resources resources-result))))
+
+        ;; Test reading a text resource
+        (let [content-future (client/read-resource test-client "file:///readme.txt")
+              content-result (.get ^CompletableFuture content-future 5 TimeUnit/SECONDS)]
+          (is (= "# Project README\nWelcome to our project!"
+                 (get-in content-result [:contents 0 :text]))))
+
+        ;; Test reading a JSON resource
+        (let [content-future (client/read-resource test-client "file:///config.json")
+              content-result (.get ^CompletableFuture content-future 5 TimeUnit/SECONDS)]
+          (is (= "{\"version\": \"1.0\", \"debug\": true}"
+                 (get-in content-result [:contents 0 :text]))))
+
+        ;; Test error handling for non-existent resource
+        (let [error-future (client/read-resource test-client "file:///nonexistent.txt")
+              error-result (.get ^CompletableFuture error-future 5 TimeUnit/SECONDS)]
+          (is (:isError error-result))
+          (is (= "file:///nonexistent.txt" (:resource-uri error-result))))
+
+        (finally
+          (client/close! test-client)
+          (stop-server! server))))))
+
+(deftest ^:integ test-client-resource-pagination
+  (testing "resource listing with pagination"
+    (ensure-in-memory-transport-registered!)
+    (let [shared-transport (shared/create-shared-transport)
+          ;; Create server with pagination support
+          handlers {"initialize" (fn [_req _params]
+                                   {:protocolVersion "2025-06-18"
+                                    :capabilities {:resources {}}
+                                    :serverInfo {:name "test-server"
+                                                 :version "1.0.0"}})
+                    "resources/list" (fn [_req params]
+                                       (if (:cursor params)
+                                         {:resources [{:uri "file:///page2.txt"
+                                                       :name "page2.txt"}]}
+                                         {:resources [{:uri "file:///page1.txt"
+                                                       :name "page1.txt"}]
+                                          :nextCursor "page2"}))}
+          create-server-fn (do
+                             (require 'mcp-clj.in-memory-transport.server)
+                             (ns-resolve
+                               'mcp-clj.in-memory-transport.server
+                               'create-in-memory-server))
+          server (create-server-fn {:shared shared-transport} handlers)
+          client-config {:transport {:type :in-memory
+                                     :shared shared-transport}
+                         :client-info {:name "test-client"
+                                       :version "1.0.0"}}
+          test-client (client/create-client client-config)]
+
+      (try
+        ;; Wait for client to initialize
+        (client/wait-for-ready test-client 5000)
+
+        ;; Test first page
+        (let [page1-future (client/list-resources test-client)
+              page1-result (.get ^CompletableFuture page1-future 5 TimeUnit/SECONDS)]
+          (is (= 1 (count (:resources page1-result))))
+          (is (= "page1.txt" (get-in page1-result [:resources 0 :name])))
+          (is (= "page2" (:nextCursor page1-result))))
+
+        ;; Test second page with cursor
+        (let [page2-future (client/list-resources test-client {:cursor "page2"})
+              page2-result (.get ^CompletableFuture page2-future 5 TimeUnit/SECONDS)]
+          (is (= 1 (count (:resources page2-result))))
+          (is (= "page2.txt" (get-in page2-result [:resources 0 :name])))
+          (is (nil? (:nextCursor page2-result))))
+
+        (finally
+          (client/close! test-client)
+          (stop-server! server))))))

--- a/components/mcp-client/test/mcp_clj/mcp_client/resources_test.clj
+++ b/components/mcp-client/test/mcp_clj/mcp_client/resources_test.clj
@@ -1,0 +1,259 @@
+(ns mcp-clj.mcp-client.resources-test
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [mcp-clj.client-transport.factory :as client-transport-factory]
+    [mcp-clj.in-memory-transport.shared :as shared]
+    [mcp-clj.mcp-client.resources :as resources]
+    [mcp-clj.server-transport.factory :as server-transport-factory])
+  (:import
+    (java.util.concurrent
+      CompletableFuture
+      TimeUnit)))
+
+;; Transport registration function for robust test isolation
+(defn ensure-in-memory-transport-registered!
+  "Ensure in-memory transport is registered in both client and server factories.
+  Can be called multiple times safely - registration is idempotent."
+  []
+  (client-transport-factory/register-transport!
+    :in-memory
+    (fn [options]
+      (require 'mcp-clj.in-memory-transport.client)
+      (let [create-fn (ns-resolve
+                        'mcp-clj.in-memory-transport.client
+                        'create-transport)]
+        (create-fn options))))
+  (server-transport-factory/register-transport!
+    :in-memory
+    (fn [options handlers]
+      (require 'mcp-clj.in-memory-transport.server)
+      (let [create-server (ns-resolve
+                            'mcp-clj.in-memory-transport.server
+                            'create-in-memory-server)]
+        (create-server options handlers)))))
+
+;; Ensure transport is registered at namespace load time
+(ensure-in-memory-transport-registered!)
+
+(defn- stop-server!
+  "Stop an in-memory server using lazy-loaded function"
+  [server]
+  (require 'mcp-clj.in-memory-transport.server)
+  ((ns-resolve 'mcp-clj.in-memory-transport.server 'stop!) server))
+
+(defn- create-test-client-with-handler
+  "Create a test client with in-memory transport and custom handler"
+  [handler]
+  ;; Ensure transport is registered before creating client/server
+  (ensure-in-memory-transport-registered!)
+  (let [shared-transport (shared/create-shared-transport)
+        session (atom {})
+        ;; Create server using lazy-loaded function
+        create-server-fn (do
+                           (require 'mcp-clj.in-memory-transport.server)
+                           (ns-resolve
+                             'mcp-clj.in-memory-transport.server
+                             'create-in-memory-server))
+        server (create-server-fn
+                 {:shared shared-transport}
+                 {"resources/list" handler
+                  "resources/read" handler})
+        ;; Create transport using lazy-loaded function
+        create-transport-fn (do (require 'mcp-clj.in-memory-transport.client)
+                                (ns-resolve
+                                  'mcp-clj.in-memory-transport.client
+                                  'create-transport))
+        transport (create-transport-fn {:shared shared-transport})]
+    {:session session
+     :transport transport
+     :server server
+     :shared-transport shared-transport}))
+
+(deftest test-list-resources-success
+  (testing "list-resources-impl returns available resources"
+    (let [mock-resources [{:uri "file:///test.txt"
+                           :name "test.txt"
+                           :description "A test text file"
+                           :mimeType "text/plain"}
+                          {:uri "file:///data.json"
+                           :name "data.json"
+                           :description "Test JSON data"}]
+          handler (fn [request _params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/list" {:resources mock-resources}
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (resources/list-resources-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= mock-resources (:resources result)))
+          (is (= 2 (count (:resources result)))))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-list-resources-with-pagination
+  (testing "list-resources-impl handles pagination correctly"
+    (let [handler (fn [request params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/list"
+                        (if (:cursor params)
+                          {:resources [{:uri "file:///page2.txt" :name "page2.txt"}]}
+                          {:resources [{:uri "file:///page1.txt" :name "page1.txt"}]
+                           :nextCursor "page2"})
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        ;; Test first page
+        (let [result-future (resources/list-resources-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [{:uri "file:///page1.txt" :name "page1.txt"}] (:resources result)))
+          (is (= "page2" (:nextCursor result))))
+
+        ;; Test second page with cursor
+        (let [result-future (resources/list-resources-impl client {:cursor "page2"})
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [{:uri "file:///page2.txt" :name "page2.txt"}] (:resources result)))
+          (is (nil? (:nextCursor result))))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-read-resource-text-success
+  (testing "read-resource-impl returns text resource content"
+    (let [mock-text-content "Hello, this is test content!"
+          handler (fn [request params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/read"
+                        (if (= "file:///test.txt" (:uri params))
+                          {:contents [{:uri "file:///test.txt"
+                                       :text mock-text-content}]}
+                          {:content [{:type "text" :text "Resource not found"}]
+                           :isError true})
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (resources/read-resource-impl client "file:///test.txt")
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= {:contents [{:uri "file:///test.txt"
+                              :text mock-text-content}]} result))
+          (is (= mock-text-content (get-in result [:contents 0 :text]))))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-read-resource-binary-success
+  (testing "read-resource-impl returns binary resource content"
+    (let [mock-binary-content "SGVsbG8gV29ybGQ=" ; "Hello World" in base64
+          handler (fn [request params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/read"
+                        (if (= "file:///image.png" (:uri params))
+                          {:contents [{:uri "file:///image.png"
+                                       :blob mock-binary-content
+                                       :mimeType "image/png"}]}
+                          {:content [{:type "text" :text "Resource not found"}]
+                           :isError true})
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (resources/read-resource-impl client "file:///image.png")
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= mock-binary-content (get-in result [:contents 0 :blob])))
+          (is (= "image/png" (get-in result [:contents 0 :mimeType]))))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-read-resource-error
+  (testing "read-resource-impl handles errors gracefully"
+    (let [handler (fn [request _params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/read" {:content [{:type "text" :text "Resource not found"}]
+                                          :isError true}
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (resources/read-resource-impl client "file:///nonexistent.txt")
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (:isError result))
+          (is (= "file:///nonexistent.txt" (:resource-uri result)))
+          (is (= [{:type "text" :text "Resource not found"}] (:content result))))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-available-resources-with-cache
+  (testing "available-resources?-impl uses cached resources when available"
+    (let [mock-resources [{:uri "file:///test.txt" :name "test.txt"}]
+          handler (fn [request _params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/list" {:resources mock-resources}
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        ;; First call should query server and cache results
+        (let [result-future (resources/list-resources-impl client)]
+          (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS))
+
+        ;; Now available-resources? should use cache
+        (is (true? (resources/available-resources?-impl client)))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-available-resources-no-cache
+  (testing "available-resources?-impl queries server when no cache"
+    (let [mock-resources [{:uri "file:///test.txt" :name "test.txt"}]
+          handler (fn [request _params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/list" {:resources mock-resources}
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        ;; Should query server directly
+        (is (true? (resources/available-resources?-impl client)))
+
+        (finally
+          (stop-server! (:server client)))))))
+
+(deftest test-empty-resources-list
+  (testing "list-resources-impl handles empty resources list"
+    (let [handler (fn [request _params]
+                    (let [method (:method request)]
+                      (case method
+                        "resources/list" {:resources []}
+                        nil)))
+          client (create-test-client-with-handler handler)]
+
+      (try
+        (let [result-future (resources/list-resources-impl client)
+              result (.get ^CompletableFuture result-future 5 TimeUnit/SECONDS)]
+
+          (is (= [] (:resources result))))
+
+        ;; Available resources should return false
+        (is (false? (resources/available-resources?-impl client)))
+
+        (finally
+          (stop-server! (:server client)))))))


### PR DESCRIPTION
Implement client-side resources functionality following established patterns:

- New mcp-clj.mcp-client.resources namespace with core implementation
- Session-level caching for resources discovery
- Support for both text and binary resource content
- Pagination support for resource listing
- CompletableFuture-based async API consistent with tools and prompts
- Integration with mcp-clj.mcp-client.core public API

API additions:
- list-resources: Discover available resources with pagination
- read-resource: Read specific resource by URI
- available-resources?: Check if resources are available