### PR TITLE
feat: Add MCP capability negotiation compliance

### DIFF
--- a/.claude/TASKS.md
+++ b/.claude/TASKS.md
@@ -121,6 +121,21 @@ Include REFINE to refine the spec
 	  server functions:
 	  https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-06-18/server/resources.mdx
 
+- [x] Add compliance with @doc/capability-negotiation.md
+
+  Implementation completed:
+  - Added capability helper functions to mcp-clj.mcp-client.session:
+    - server-supports?, server-supports-tools?, server-supports-prompts?,
+      server-supports-resources?, server-supports-sampling?
+    - client-supports?, client-supports-sampling?, client-supports-notifications?
+  - Client checks server capabilities before making requests in:
+    - mcp-clj.mcp-client.tools (list-tools-impl, call-tool-impl, available-tools?-impl)
+    - mcp-clj.mcp-client.prompts (list-prompts-impl, get-prompt-impl, available-prompts?-impl)
+    - mcp-clj.mcp-client.resources (list-resources-impl, read-resource-impl, available-resources?-impl)
+  - Returns error futures with logging when capabilities are missing
+  - Server has capability helper functions for future use with notifications and sampling
+  - Comprehensive test coverage in mcp-clj.mcp-client.session-test
+
 - [ ] extend the interop to enable use of SSE transport ? not sure this
       is worth doing still
 

--- a/components/mcp-client/src/mcp_clj/mcp_client/resources.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/resources.clj
@@ -1,11 +1,12 @@
 (ns mcp-clj.mcp-client.resources
   "Resource access implementation for MCP client"
   (:require
-    [mcp-clj.log :as log]
-    [mcp-clj.mcp-client.transport :as transport])
+   [mcp-clj.log :as log]
+   [mcp-clj.mcp-client.session :as session]
+   [mcp-clj.mcp-client.transport :as transport])
   (:import
-    (java.util.concurrent
-      CompletableFuture)))
+   (java.util.concurrent
+    CompletableFuture)))
 
 (defn- get-resources-cache
   "Get or create resources cache in client session"
@@ -38,27 +39,35 @@
   Supports pagination with optional :cursor parameter."
   ^CompletableFuture [client & [{:keys [cursor]}]]
   (try
-    (let [transport (:transport client)
-          params (cond-> {}
-                   cursor (assoc :cursor cursor))
-          response (transport/send-request!
-                     transport
-                     "resources/list"
-                     params
-                     30000)]
-      ;; Transform the response future to handle caching and return resources
-      (.thenApply response
-                  (reify java.util.function.Function
-                    (apply
-                      [_ result]
-                      (if-let [resources (:resources result)]
-                        (do
-                          (when-not cursor ; Only cache first page
-                            (cache-resources! client resources))
-                          (cond-> {:resources resources}
-                            (:nextCursor result)
-                            (assoc :nextCursor (:nextCursor result))))
-                        {:resources []})))))
+    (let [session @(:session client)]
+      (if-not (session/server-supports-resources? session)
+        (do
+          (log/warn :client/resources-not-supported
+                    {:server-capabilities (:server-capabilities session)})
+          (CompletableFuture/failedFuture
+           (ex-info "Server does not support resources capability"
+                    {:server-capabilities (:server-capabilities session)})))
+        (let [transport (:transport client)
+              params (cond-> {}
+                       cursor (assoc :cursor cursor))
+              response (transport/send-request!
+                        transport
+                        "resources/list"
+                        params
+                        30000)]
+          ;; Transform the response future to handle caching and return resources
+          (.thenApply response
+                      (reify java.util.function.Function
+                        (apply
+                          [_ result]
+                          (if-let [resources (:resources result)]
+                            (do
+                              (when-not cursor ; Only cache first page
+                                (cache-resources! client resources))
+                              (cond-> {:resources resources}
+                                (:nextCursor result)
+                                (assoc :nextCursor (:nextCursor result))))
+                            {:resources []})))))))
     (catch Exception e
       (log/error :client/list-resources-error {:error (.getMessage e)})
       ;; Return a failed future for immediate exceptions
@@ -74,43 +83,52 @@
   ^CompletableFuture [client resource-uri]
   (log/info :client/read-resource-start {:resource-uri resource-uri})
   (try
-    (let [transport (:transport client)
-          params {:uri resource-uri}]
-      (.thenApply
-        (transport/send-request!
-          transport
-          "resources/read"
-          params
-          30000)
-        (reify java.util.function.Function
-          (apply
-            [_ result]
-            (let [is-error (:isError result false)]
-              (if is-error
-                (do
-                  (log/error :client/read-resource-error
-                             {:resource-uri resource-uri
-                              :content (:content result)})
-                  ;; Return error map instead of throwing
-                  {:isError true
-                   :resource-uri resource-uri
-                   :content (:content result)})
-                (do
-                  (log/info :client/read-resource-success
-                            {:resource-uri resource-uri})
-                  ;; Return the resource content
-                  result)))))))
+    (let [session @(:session client)]
+      (if-not (session/server-supports-resources? session)
+        (do
+          (log/warn :client/resources-not-supported
+                    {:server-capabilities (:server-capabilities session)})
+          (CompletableFuture/failedFuture
+           (ex-info "Server does not support resources capability"
+                    {:server-capabilities (:server-capabilities session)
+                     :resource-uri resource-uri})))
+        (let [transport (:transport client)
+              params {:uri resource-uri}]
+          (.thenApply
+           (transport/send-request!
+            transport
+            "resources/read"
+            params
+            30000)
+           (reify java.util.function.Function
+             (apply
+               [_ result]
+               (let [is-error (:isError result false)]
+                 (if is-error
+                   (do
+                     (log/error :client/read-resource-error
+                                {:resource-uri resource-uri
+                                 :content (:content result)})
+                     ;; Return error map instead of throwing
+                     {:isError true
+                      :resource-uri resource-uri
+                      :content (:content result)})
+                   (do
+                     (log/info :client/read-resource-success
+                               {:resource-uri resource-uri})
+                     ;; Return the resource content
+                     result)))))))))
     (catch Exception e
       ;; Return a failed future for immediate exceptions (like transport errors)
       (log/error :client/read-resource-error {:resource-uri resource-uri
                                               :error (.getMessage e)
                                               :ex e})
       (CompletableFuture/failedFuture
-        (ex-info
-          (str "Resource read failed: " resource-uri)
-          {:resource-uri resource-uri
-           :error (.getMessage e)}
-          e)))))
+       (ex-info
+        (str "Resource read failed: " resource-uri)
+        {:resource-uri resource-uri
+         :error (.getMessage e)}
+        e)))))
 
 (defn available-resources?-impl
   "Check if any resources are available from the server.
@@ -119,11 +137,17 @@
   Uses cached resources if available, otherwise queries the server."
   [client]
   (try
-    (if-let [cached-resources (get-cached-resources client)]
-      (boolean (seq cached-resources))
-      (when-let [result-future (list-resources-impl client)]
-        (let [result @result-future]
-          (boolean (seq (:resources result))))))
+    (let [session @(:session client)]
+      (if-not (session/server-supports-resources? session)
+        (do
+          (log/debug :client/resources-not-supported
+                     {:server-capabilities (:server-capabilities session)})
+          false)
+        (if-let [cached-resources (get-cached-resources client)]
+          (boolean (seq cached-resources))
+          (when-let [result-future (list-resources-impl client)]
+            (let [result @result-future]
+              (boolean (seq (:resources result))))))))
     (catch Exception e
       (log/debug :client/available-resources-error {:error (.getMessage e)})
       false)))

--- a/components/mcp-client/src/mcp_clj/mcp_client/session.clj
+++ b/components/mcp-client/src/mcp_clj/mcp_client/session.clj
@@ -1,7 +1,7 @@
 (ns mcp-clj.mcp-client.session
   "MCP client session state management"
   (:require
-    [mcp-clj.log :as log]))
+   [mcp-clj.log :as log]))
 
 ;; Session States
 
@@ -10,13 +10,13 @@
 ;; Session Record
 
 (defrecord Session
-  [state ; Current session state
-   client-info ; Client information sent in initialize
-   capabilities ; Client capabilities
-   server-info ; Server info from initialize response
-   server-capabilities ; Server capabilities from initialize response
-   protocol-version ; Negotiated protocol version
-   error-info]) ; Error information if state is :error
+           [state ; Current session state
+            client-info ; Client information sent in initialize
+            capabilities ; Client capabilities
+            server-info ; Server info from initialize response
+            server-capabilities ; Server capabilities from initialize response
+            protocol-version ; Negotiated protocol version
+            error-info]) ; Error information if state is :error
 
 ;; Session State Transitions
 
@@ -42,13 +42,13 @@
          capabilities {}
          protocol-version "2025-06-18"}}]
   (->Session
-    :disconnected
-    client-info
-    capabilities
-    nil ; server-info
-    nil ; server-capabilities
-    protocol-version
-    nil)) ; error-info
+   :disconnected
+   client-info
+   capabilities
+   nil ; server-info
+   nil ; server-capabilities
+   protocol-version
+   nil)) ; error-info
 
 (defn transition-state!
   "Transition session to new state with optional data"
@@ -86,10 +86,56 @@
 (defn get-session-info
   "Get human-readable session information"
   [session]
-  {:state               (:state session)
-   :protocol-version    (:protocol-version session)
-   :client-info         (:client-info session)
+  {:state (:state session)
+   :protocol-version (:protocol-version session)
+   :client-info (:client-info session)
    :client-capabilities (:capabilities session)
-   :server-info         (:server-info session)
+   :server-info (:server-info session)
    :server-capabilities (:server-capabilities session)
-   :error-info          (:error-info session)})
+   :error-info (:error-info session)})
+
+(defn server-supports?
+  "Check if server supports a specific capability.
+
+  Capability path is a vector of keys, e.g., [:tools] or [:resources :subscribe].
+  Returns boolean indicating if the capability is present and truthy."
+  [session capability-path]
+  (boolean (get-in (:server-capabilities session) capability-path)))
+
+(defn server-supports-tools?
+  "Check if server supports tools capability"
+  [session]
+  (server-supports? session [:tools]))
+
+(defn server-supports-prompts?
+  "Check if server supports prompts capability"
+  [session]
+  (server-supports? session [:prompts]))
+
+(defn server-supports-resources?
+  "Check if server supports resources capability"
+  [session]
+  (server-supports? session [:resources]))
+
+(defn server-supports-sampling?
+  "Check if server supports sampling capability"
+  [session]
+  (server-supports? session [:sampling]))
+
+(defn client-supports?
+  "Check if client supports a specific capability.
+
+  Capability path is a vector of keys, e.g., [:sampling] or [:notifications].
+  Returns boolean indicating if the capability is present and truthy."
+  [session capability-path]
+  (boolean (get-in (:capabilities session) capability-path)))
+
+(defn client-supports-sampling?
+  "Check if client supports sampling capability"
+  [session]
+  (client-supports? session [:sampling]))
+
+(defn client-supports-notifications?
+  "Check if client supports notification handling"
+  [session]
+  (client-supports? session [:notifications]))

--- a/components/mcp-client/test/mcp_clj/mcp_client/session_test.clj
+++ b/components/mcp-client/test/mcp_clj/mcp_client/session_test.clj
@@ -1,8 +1,8 @@
 (ns mcp-clj.mcp-client.session-test
   "Tests for MCP client session management"
   (:require
-    [clojure.test :refer [deftest is testing]]
-    [mcp-clj.mcp-client.session :as session]))
+   [clojure.test :refer [deftest is testing]]
+   [mcp-clj.mcp-client.session :as session]))
 
 (deftest create-session-test
   (testing "Create session with defaults"
@@ -19,9 +19,9 @@
     (let [client-info {:name "test" :version "1.0.0"}
           capabilities {:test true}
           session (session/create-session
-                    {:client-info client-info
-                     :capabilities capabilities
-                     :protocol-version "2024-11-05"})]
+                   {:client-info client-info
+                    :capabilities capabilities
+                    :protocol-version "2024-11-05"})]
       (is (= :disconnected (:state session)))
       (is (= "2024-11-05" (:protocol-version session)))
       (is (= capabilities (:capabilities session)))
@@ -36,14 +36,14 @@
 
           ;; initializing -> ready
           session3 (session/transition-state!
-                     session2 :ready
-                     :server-info {:name "test-server"}
-                     :server-capabilities {:tools true})
+                    session2 :ready
+                    :server-info {:name "test-server"}
+                    :server-capabilities {:tools true})
 
           ;; ready -> error
           session4 (session/transition-state!
-                     session3 :error
-                     :error-info {:type :connection-lost})
+                    session3 :error
+                    :error-info {:type :connection-lost})
 
           ;; error -> disconnected (clears server info)
           session5 (session/transition-state! session4 :disconnected)]
@@ -64,7 +64,7 @@
 
       ;; disconnected -> ready is invalid
       (is (thrown? Exception
-            (session/transition-state! session :ready)))
+                   (session/transition-state! session :ready)))
 
       ;; Create ready session
       (let [ready-session (-> session
@@ -72,7 +72,7 @@
                               (session/transition-state! :ready))]
         ;; ready -> initializing is invalid
         (is (thrown? Exception
-              (session/transition-state! ready-session :initializing)))))))
+                     (session/transition-state! ready-session :initializing)))))))
 
 (deftest session-predicates-test
   (testing "Session state predicates"
@@ -96,17 +96,17 @@
 
 (deftest get-session-info-test
   (testing "Get comprehensive session information"
-    (let [session       (session/create-session
-                          {:client-info      {:name "test-client"}
-                           :capabilities     {:test true}
-                           :protocol-version "2024-11-05"})
+    (let [session (session/create-session
+                   {:client-info {:name "test-client"}
+                    :capabilities {:test true}
+                    :protocol-version "2024-11-05"})
           ready-session (-> session
                             (session/transition-state! :initializing)
                             (session/transition-state!
-                              :ready
-                              :server-info {:name "test-server"}
-                              :server-capabilities {:tools true}))
-          info          (session/get-session-info ready-session)]
+                             :ready
+                             :server-info {:name "test-server"}
+                             :server-capabilities {:tools true}))
+          info (session/get-session-info ready-session)]
 
       (is (= :ready (:state info)))
       (is (= "2024-11-05" (:protocol-version info)))
@@ -115,3 +115,100 @@
       (is (= {:name "test-server"} (:server-info info)))
       (is (= {:tools true} (:server-capabilities info)))
       (is (nil? (:error-info info))))))
+
+(deftest capability-checking-test
+  ;; Test server capability checking
+  (testing "server-supports? with various capability paths"
+    (let [session (-> (session/create-session {})
+                      (session/transition-state! :initializing)
+                      (session/transition-state!
+                       :ready
+                       :server-capabilities {:tools {:listChanged true}
+                                             :resources {:subscribe false}
+                                             :prompts {}}))]
+      (is (session/server-supports? session [:tools]))
+      (is (session/server-supports? session [:tools :listChanged]))
+      (is (session/server-supports? session [:prompts]))
+      (is (not (session/server-supports? session [:resources :subscribe])))
+      (is (not (session/server-supports? session [:sampling])))
+      (is (not (session/server-supports? session [:nonexistent])))))
+
+  (testing "server-supports-tools?"
+    (let [session-with-tools (-> (session/create-session {})
+                                 (session/transition-state! :initializing)
+                                 (session/transition-state!
+                                  :ready
+                                  :server-capabilities {:tools {}}))
+          session-without-tools (-> (session/create-session {})
+                                    (session/transition-state! :initializing)
+                                    (session/transition-state!
+                                     :ready
+                                     :server-capabilities {}))]
+      (is (session/server-supports-tools? session-with-tools))
+      (is (not (session/server-supports-tools? session-without-tools)))))
+
+  (testing "server-supports-prompts?"
+    (let [session-with-prompts (-> (session/create-session {})
+                                   (session/transition-state! :initializing)
+                                   (session/transition-state!
+                                    :ready
+                                    :server-capabilities {:prompts {}}))
+          session-without-prompts (-> (session/create-session {})
+                                      (session/transition-state! :initializing)
+                                      (session/transition-state!
+                                       :ready
+                                       :server-capabilities {}))]
+      (is (session/server-supports-prompts? session-with-prompts))
+      (is (not (session/server-supports-prompts? session-without-prompts)))))
+
+  (testing "server-supports-resources?"
+    (let [session-with-resources (-> (session/create-session {})
+                                     (session/transition-state! :initializing)
+                                     (session/transition-state!
+                                      :ready
+                                      :server-capabilities {:resources {}}))
+          session-without-resources (-> (session/create-session {})
+                                        (session/transition-state! :initializing)
+                                        (session/transition-state!
+                                         :ready
+                                         :server-capabilities {}))]
+      (is (session/server-supports-resources? session-with-resources))
+      (is (not (session/server-supports-resources? session-without-resources)))))
+
+  (testing "server-supports-sampling?"
+    (let [session-with-sampling (-> (session/create-session {})
+                                    (session/transition-state! :initializing)
+                                    (session/transition-state!
+                                     :ready
+                                     :server-capabilities {:sampling {}}))
+          session-without-sampling (-> (session/create-session {})
+                                       (session/transition-state! :initializing)
+                                       (session/transition-state!
+                                        :ready
+                                        :server-capabilities {}))]
+      (is (session/server-supports-sampling? session-with-sampling))
+      (is (not (session/server-supports-sampling? session-without-sampling)))))
+
+  ;; Test client capability checking
+  (testing "client-supports? with various capability paths"
+    (let [session (session/create-session
+                   {:capabilities {:sampling {}
+                                   :notifications {:enabled true}}})]
+      (is (session/client-supports? session [:sampling]))
+      (is (session/client-supports? session [:notifications :enabled]))
+      (is (not (session/client-supports? session [:tools])))
+      (is (not (session/client-supports? session [:nonexistent])))))
+
+  (testing "client-supports-sampling?"
+    (let [session-with-sampling (session/create-session
+                                 {:capabilities {:sampling {}}})
+          session-without-sampling (session/create-session {})]
+      (is (session/client-supports-sampling? session-with-sampling))
+      (is (not (session/client-supports-sampling? session-without-sampling)))))
+
+  (testing "client-supports-notifications?"
+    (let [session-with-notifications (session/create-session
+                                      {:capabilities {:notifications {}}})
+          session-without-notifications (session/create-session {})]
+      (is (session/client-supports-notifications? session-with-notifications))
+      (is (not (session/client-supports-notifications? session-without-notifications))))))

--- a/components/mcp-server/src/mcp_clj/mcp_server/core.clj
+++ b/components/mcp-server/src/mcp_clj/mcp_server/core.clj
@@ -1,33 +1,33 @@
 (ns mcp-clj.mcp-server.core
   "MCP server implementation supporting the Anthropic Model Context Protocol"
   (:require
-    [clojure.set :as set]
-    [mcp-clj.json-rpc.protocols :as json-rpc-protocols]
-    [mcp-clj.log :as log]
-    [mcp-clj.mcp-server.prompts :as prompts]
-    [mcp-clj.mcp-server.resources :as resources]
-    [mcp-clj.mcp-server.version :as version]
-    [mcp-clj.server-transport.factory :as transport-factory]
-    [mcp-clj.tools.core :as tools])
+   [clojure.set :as set]
+   [mcp-clj.json-rpc.protocols :as json-rpc-protocols]
+   [mcp-clj.log :as log]
+   [mcp-clj.mcp-server.prompts :as prompts]
+   [mcp-clj.mcp-server.resources :as resources]
+   [mcp-clj.mcp-server.version :as version]
+   [mcp-clj.server-transport.factory :as transport-factory]
+   [mcp-clj.tools.core :as tools])
   (:import
-    (java.lang
-      AutoCloseable)))
+   (java.lang
+    AutoCloseable)))
 
 (declare stop!)
 
 (defrecord ^:private Session
-  [^String session-id
-   initialized?
-   client-info
-   client-capabilities
-   protocol-version])
+           [^String session-id
+            initialized?
+            client-info
+            client-capabilities
+            protocol-version])
 
 (defrecord ^:private MCPServer
-  [json-rpc-server
-   session-id->session
-   tool-registry
-   prompt-registry
-   resource-registry]
+           [json-rpc-server
+            session-id->session
+            tool-registry
+            prompt-registry
+            resource-registry]
 
   AutoCloseable
 
@@ -43,41 +43,59 @@
         session-id->session (:session-id->session server)]
     (get @session-id->session session-id)))
 
+(defn- client-supports?
+  "Check if client supports a specific capability.
+
+  Capability path is a vector of keys, e.g., [:sampling] or [:notifications].
+  Returns boolean indicating if the capability is present and truthy."
+  [session capability-path]
+  (boolean (get-in (:client-capabilities session) capability-path)))
+
+(defn- client-supports-sampling?
+  "Check if client supports sampling capability"
+  [session]
+  (client-supports? session [:sampling]))
+
+(defn- client-supports-notifications?
+  "Check if client supports notification handling"
+  [session]
+  (client-supports? session [:notifications]))
+
 (defn- notify-tools-changed!
   "Notify all sessions that the tool list has changed"
   [server]
   (log/info :server/notify-tools-changed {:server server})
   (json-rpc-protocols/notify-all!
-    @(:json-rpc-server server)
-    "notifications/tools/list_changed"
-    nil))
+   @(:json-rpc-server server)
+   "notifications/tools/list_changed"
+   nil))
 
 (defn- notify-prompts-changed!
   "Notify all sessions that the prompt list has changed"
   [server]
   (log/info :server/notify-prompts-changed {:server server})
   (json-rpc-protocols/notify-all!
-    @(:json-rpc-server server)
-    "notifications/prompts/list_changed"
-    nil))
+   @(:json-rpc-server server)
+   "notifications/prompts/list_changed"
+   nil))
 
 (defn- notify-resources-changed!
   "Notify all sessions that the resource list has changed"
   [server]
   (log/info :server/notify-resources-changed {:server server})
   (json-rpc-protocols/notify-all!
-    @(:json-rpc-server server)
-    "notifications/resources/list_changed"
-    nil))
+   @(:json-rpc-server server)
+   "notifications/resources/list_changed"
+   nil))
 
 (defn- notify-resource-updated!
   "Notify all sessions that a resource has been updated"
   [server uri]
   (log/info :server/notify-resource-updated {:server server :uri uri})
   (json-rpc-protocols/notify-all!
-    @(:json-rpc-server server)
-    "notifications/resources/updated"
-    {:uri uri}))
+   @(:json-rpc-server server)
+   "notifications/resources/updated"
+   {:uri uri}))
 
 (defn- text-map
   [msg]
@@ -125,18 +143,18 @@
                            :prompts {:listChanged true}}
         ;; Apply version-specific capability formatting
         version-capabilities (version/handle-version-specific-behavior
-                               negotiated-version
-                               :capabilities
-                               {:capabilities base-capabilities})
+                              negotiated-version
+                              :capabilities
+                              {:capabilities base-capabilities})
         ;; Create base server info
         base-server-info {:name "mcp-clj"
                           :version "0.1.0"
                           :title "MCP Clojure Server"}
         ;; Apply version-specific server info formatting
         version-server-info (version/handle-version-specific-behavior
-                              negotiated-version
-                              :server-info
-                              {:server-info base-server-info})]
+                             negotiated-version
+                             :server-info
+                             {:server-info base-server-info})]
     (log/info :server/mcp-version
               {:negotiated-version negotiated-version
                :warnings warnings})
@@ -193,17 +211,17 @@
   [server {:keys [name arguments] :as _params}]
   (log/info :server/tools-call)
   (if-let [{:keys [implementation inputSchema]} (get
-                                                  @(:tool-registry server)
-                                                  name)]
+                                                 @(:tool-registry server)
+                                                 name)]
     (try
       (let [missing-args (set/difference
-                           (set (mapv keyword (:required inputSchema)))
-                           (set (keys arguments)))]
+                          (set (mapv keyword (:required inputSchema)))
+                          (set (keys arguments)))]
         (if (empty? missing-args)
           (transform-tool-result (implementation arguments))
           {:content [(text-map
-                       (str "Missing args: " (vec missing-args) ", found "
-                            (set (keys arguments))))]
+                      (str "Missing args: " (vec missing-args) ", found "
+                           (set (keys arguments))))]
            :isError true}))
       (catch Throwable e
         {:content [(text-map (str "Error: " (.getMessage e)))]
@@ -216,9 +234,9 @@
   [server protocol-version params]
   (let [base-response (handle-call-tool server params)]
     (version/handle-version-specific-behavior
-      protocol-version
-      :tool-response
-      base-response)))
+     protocol-version
+     :tool-response
+     base-response)))
 
 (defn- handle-list-resources
   "Handle resources/list request from client"
@@ -295,10 +313,10 @@
             nil)
           (do
             (log/warn
-              :server/error
-              {:msg "missing mcp session"
-               :request request
-               :params params})
+             :server/error
+             {:msg "missing mcp session"
+              :request request
+              :params params})
             (response nil)
             nil)))
 
@@ -309,19 +327,19 @@
   "Create request handlers with server reference"
   [server]
   (update-vals
-    {"initialize" handle-initialize
-     "notifications/initialized" handle-initialized
-     "ping" handle-ping
-     "tools/list" handle-list-tools
-     "tools/call" handle-call-tool
-     "resources/list" handle-list-resources
-     "resources/read" handle-read-resource
-     "resources/subscribe" handle-subscribe-resource
-     "resources/unsubscribe" handle-unsubscribe-resource
-     "prompts/list" handle-list-prompts
-     "prompts/get" handle-get-prompt}
-    (fn [handler]
-      #(request-handler server handler %1 %2))))
+   {"initialize" handle-initialize
+    "notifications/initialized" handle-initialized
+    "ping" handle-ping
+    "tools/list" handle-list-tools
+    "tools/call" handle-call-tool
+    "resources/list" handle-list-resources
+    "resources/read" handle-read-resource
+    "resources/subscribe" handle-subscribe-resource
+    "resources/unsubscribe" handle-unsubscribe-resource
+    "prompts/list" handle-list-prompts
+    "prompts/get" handle-get-prompt}
+   (fn [handler]
+     #(request-handler server handler %1 %2))))
 
 (defn add-tool!
   "Add or update a tool in a running server"
@@ -419,17 +437,17 @@
                     :prompts {...}})"
   ^MCPServer
   [{:keys [transport tools prompts resources]
-    :or   {tools     tools/default-tools
-           prompts   prompts/default-prompts
-           resources resources/default-resources}
-    :as   opts}]
+    :or {tools tools/default-tools
+         prompts prompts/default-prompts
+         resources resources/default-resources}
+    :as opts}]
   (when-not transport
     (throw (ex-info "Missing :transport configuration"
-                    {:config   opts
+                    {:config opts
                      :expected "Map with :type key and transport-specific options"})))
   (when-not (:type transport)
     (throw (ex-info "Missing :type in transport configuration"
-                    {:transport       transport
+                    {:transport transport
                      :supported-types [:stdio :sse :http]})))
   (doseq [tool (vals tools)]
     (when-not (tools/valid-tool? tool)
@@ -437,33 +455,33 @@
   (doseq [prompt (vals prompts)]
     (when-not (prompts/valid-prompt? prompt)
       (throw (ex-info "Invalid prompt in constructor" {:prompt prompt}))))
-  (let [session-id->session      (atom {})
-        tool-registry            (atom tools)
-        prompt-registry          (atom prompts)
-        resource-registry        (atom resources)
-        rpc-server-prom          (promise)
-        server                   (->MCPServer
-                                   rpc-server-prom
-                                   session-id->session
-                                   tool-registry
-                                   prompt-registry
-                                   resource-registry)
+  (let [session-id->session (atom {})
+        tool-registry (atom tools)
+        prompt-registry (atom prompts)
+        resource-registry (atom resources)
+        rpc-server-prom (promise)
+        server (->MCPServer
+                rpc-server-prom
+                session-id->session
+                tool-registry
+                prompt-registry
+                resource-registry)
         ;; Create handlers before creating the JSON-RPC server to avoid race
         ;; conditions
-        handlers                 (create-handlers server)
+        handlers (create-handlers server)
         ;; Add callbacks to transport options
         transport-with-callbacks (merge transport
                                         {:on-sse-connect (partial on-sse-connect server)
-                                         :on-sse-close   (partial on-sse-close server)})
-        json-rpc-server          (transport-factory/create-transport
-                                   transport-with-callbacks
-                                   handlers)
-        server                   (assoc server
-                                        :stop #(do
-                                                 (log/info :server/stopping {})
-                                                 (stop! server)
-                                                 (json-rpc-protocols/stop! json-rpc-server)
-                                                 (log/info :server/stopped {})))]
+                                         :on-sse-close (partial on-sse-close server)})
+        json-rpc-server (transport-factory/create-transport
+                         transport-with-callbacks
+                         handlers)
+        server (assoc server
+                      :stop #(do
+                               (log/info :server/stopping {})
+                               (stop! server)
+                               (json-rpc-protocols/stop! json-rpc-server)
+                               (log/info :server/stopped {})))]
     ;; Set handlers immediately after creating the JSON-RPC server to minimize
     ;; race window
     (json-rpc-protocols/set-handlers! json-rpc-server handlers)


### PR DESCRIPTION
Add capability checking to client and server following MCP spec:

Client changes:
- Add capability helper functions in mcp-client.session
- Check server capabilities before making requests in tools, prompts, and resources
- Return error futures with logging when capabilities missing
- Update available-*? functions to check capabilities first

Server changes:
- Add capability helper functions for client capability checking
- Prepare infrastructure for future notification and sampling guards