### PR TITLE
chore: Add MCP protocol specification as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/mcp-protocol"]
+	path = spec/mcp-protocol
+	url = https://github.com/modelcontextprotocol/modelcontextprotocol.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@
 This file provides guidance to Claude Code (claude.ai/code) when working
 with code in this repository.
 
+@doc/glossary.md
+@doc/mcp-specification.md
+
 ## Architecture Overview
 
 This is a Clojure implementation of the Model Context Protocol (MCP)
@@ -37,6 +40,18 @@ organization:
 
 - `sse-server/` - Server-Sent Events (SSE) transport server base
 - `stdio-server/` - Standard I/O transport server base
+
+Each operation for a server capability is implemented has a handler in
+the mcp-server component in the `mcp-clj.mcp-server.core` namespace.
+The implementation for implementing each capability is in the
+`mcp-clj.mcp-server.<capability>` namespace.
+
+Each operation for a server capability is exposed in the mcp-client
+component in the `mcp-clj.mcp-client.core` namespace.  The
+implementation for exposing each capability is in the
+`mcp-clj.mcp-client.<capability>` namespace.
+
+Concerns follow the same pattern as capabilities.
 
 ### Key Design Patterns
 
@@ -186,8 +201,6 @@ clj -M:stdio-server
 - Component isolation: changes to one component should not require
   changes to others unless interfaces change
 
-- mcp protocol specification is at
-  https://github.com/modelcontextprotocol/modelcontextprotocol/tree/main/docs/specification
-
 - use `str/includes?` rather than `.contains`
 - run `cljstyle fix` before committing
+- use semantic commit and PR messages

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,0 +1,71 @@
+# Project Glossary
+
+**Base**: Entry point implementation that composes components into a deployable artifact (e.g., sse-server, stdio-server).
+
+**Capabilities**: Feature flags exchanged during initialization indicating supported MCP features (tools, prompts, resources, sampling, roots, logging).
+
+**Client Info**: Metadata about an MCP client including name, version, and optionally title, exchanged during initialization.
+
+**Component**: Reusable functionality module with isolated dependencies in the polylith architecture (e.g., mcp-server, json-rpc, tools).
+
+**Cursor**: Opaque string token representing a position in paginated result sets; clients must treat as opaque.
+
+**EDN**: Extended Data Notation - Clojure's data format used internally by handlers before JSON conversion.
+
+**Handler**: Function that processes JSON-RPC method calls by accepting EDN parameters and returning EDN responses.
+
+**Implementation**: The actual function in a tool, prompt, or resource that executes when invoked by a client.
+
+**In-Memory Transport**: Transport layer for testing that enables bidirectional client-server communication without external processes or network.
+
+**Initialize**: First MCP protocol method called by client to establish session, negotiate protocol version, and exchange capabilities.
+
+**Initialized**: Notification sent by client after receiving initialize response to confirm session establishment and readiness.
+
+**inputSchema**: JSON Schema definition specifying required and optional parameters for a tool.
+
+**JSON-RPC Client**: Component implementing JSON-RPC 2.0 client protocol with request/response handling and notification support.
+
+**JSON-RPC Server**: Component implementing JSON-RPC 2.0 server protocol with automatic EDN/JSON conversion and handler dispatch.
+
+**Lifecycle**: The three-phase connection flow: initialization (capability negotiation), operation (normal communication), and shutdown (graceful termination).
+
+**listChanged**: Capability sub-flag indicating support for notifications when lists of tools, prompts, or resources change.
+
+**MCP**: Model Context Protocol - Anthropic's protocol for enabling communication between AI assistants and context providers.
+
+**Negotiation**: Process during initialization where client and server agree on protocol version to use for the session.
+
+**Notification**: JSON-RPC message sent without expecting a response, used for events like "tools/list_changed" or "initialized".
+
+**Pagination**: Cursor-based approach for retrieving large result sets in smaller chunks; servers determine page size.
+
+**Polylith**: Architecture style organizing code into components, bases, and projects with isolated dependencies and clear boundaries.
+
+**Prompt**: MCP feature that provides pre-defined message templates with parameters that can be filled in by clients.
+
+**Protocol Version**: MCP specification version string (e.g., "2024-11-05", "2025-03-26") following YYYY-MM-DD format; negotiated during initialization.
+
+**Registry**: Component managing dynamic collections of tools, prompts, or resources with support for add/remove and change notifications.
+
+**Resource**: MCP feature that provides access to data sources like files or API endpoints with URI-based addressing.
+
+**Roots**: Filesystem directories/files that clients expose to servers, defining operational boundaries and access scope.
+
+**Sampling**: MCP capability allowing servers to request LLM completions from clients with human-in-the-loop approval.
+
+**Server Info**: Metadata about an MCP server including name, version, and optionally title, sent during initialization.
+
+**Session**: Client connection state including session ID, initialization status, client info, capabilities, and protocol version.
+
+**SSE**: Server-Sent Events - HTTP-based transport using EventSource for server-to-client streaming with endpoint message posting.
+
+**STDIO**: Standard Input/Output transport for MCP communication over stdin/stdout, commonly used with Claude Desktop.
+
+**Subscribe**: Capability sub-flag for resources indicating support for receiving notifications when individual resource content changes.
+
+**Tool**: MCP feature that exposes executable functionality with name, description, input schema, and implementation function.
+
+**Transport**: Abstraction layer for communication between client and server (stdio, SSE, HTTP, in-memory).
+
+**Version-Aware**: Code that adapts behavior based on negotiated protocol version to maintain compatibility across MCP specification versions.

--- a/doc/mcp-specification.md
+++ b/doc/mcp-specification.md
@@ -1,0 +1,29 @@
+# About the MCP Specification
+
+The MCP specification is available in @spec/mcp-protocol.
+
+Known versions are directories under @spec/mcp-protocol/docs/specification.
+
+Version negotiation is specified in
+@spec/mcp-protocol/docs/specification/versioning.mdx.
+
+Version changelog may be available in
+@spec/mcp-protocol/docs/specification/<version>/changelog.mdx
+
+Client capabilities are described in
+@spec/mcp-protocol/docs/specification/<version>/client/<capability>.mdx
+
+Server capabilities are described in
+@spec/mcp-protocol/docs/specification/<version>/server/<capability>.mdx
+
+Server utilities are described in
+@spec/mcp-protocol/docs/specification/<version>/server/utilities/<utility>.mdx
+
+Cross cutting concerns (both client and server) are described in
+@spec/mcp-protocol/docs/specification/<version>/basic/<concern>.mdx
+
+Transports are described in
+@spec/mcp-protocol/docs/specification/<version>/basic/transports.mdx
+
+Schemas for all messages in each version are in:
+@spec/mcp-protocol/schema/<version>/schema.json


### PR DESCRIPTION
## Summary
- Add the official MCP protocol specification repository as a git submodule at `spec/mcp-protocol`

This provides easy reference to the specification documents and allows tracking which version is being implemented.
