### PR TITLE
feat: add build infrastructure for JAR generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /reflection-warnings.log
+
+# Build artifacts
+projects/*/target/

--- a/deps.edn
+++ b/deps.edn
@@ -88,4 +88,7 @@
                  :exec-fn mcp-clj.stdio-server.main/start
                  :deps {poly/server {:local/root "projects/server"}
                         org.clojure/clojure {:mvn/version "1.12.0"}}
-                 :jvm-opts ["-Djdk.attach.allowAttachSelf"]}}}
+                 :jvm-opts ["-Djdk.attach.allowAttachSelf"]}
+  :build {:extra-paths ["dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build}}}

--- a/dev/build.clj
+++ b/dev/build.clj
@@ -1,0 +1,127 @@
+(ns build
+  "Build script for mcp-clj projects using tools.build.
+
+  Provides functions for building JAR files with automatic version numbering
+  based on git commit count. All projects share the same version number.
+
+  Usage:
+    clj -T:build jar :project-name '\"server\"' :lib 'io.github.hugoduncan/mcp-clj-server'
+    clj -T:build clean :project-name '\"server\"'
+    clj -T:build version
+
+  The :build alias in each project's deps.edn configures the project-specific
+  parameters."
+  (:require [clojure.tools.build.api :as b]))
+
+(def major-minor "0.1")
+(def root-dir
+  "Find the repository root by looking for deps.edn with :build alias."
+  (let [cwd (System/getProperty "user.dir")]
+    (loop [dir (clojure.java.io/file cwd)]
+      (cond
+        (nil? dir) cwd
+        (.exists (clojure.java.io/file dir "dev" "build.clj")) (.getPath dir)
+        :else (recur (.getParentFile dir))))))
+
+(defn version
+  "Calculate version string from git commit count.
+
+  Returns a version string in format 'major.minor.commit-count'."
+  [_opts]
+  (let [commit-count (b/git-count-revs nil)
+        v (format "%s.%s" major-minor commit-count)]
+    (println "Version:" v)
+    v))
+
+(defn- project-target-dir
+  "Get target directory for a project."
+  [project-name]
+  (str root-dir "/projects/" project-name "/target"))
+
+(defn- project-class-dir
+  "Get classes directory for a project."
+  [project-name]
+  (str (project-target-dir project-name) "/classes"))
+
+(defn- jar-file-path
+  "Get JAR file path for a project."
+  [project-name version]
+  (format "%s/mcp-clj-%s-%s.jar"
+          (project-target-dir project-name)
+          project-name
+          version))
+
+(defn clean
+  "Remove target directory for a project.
+
+  Options:
+    :project-name - Name of the project (e.g., 'server', 'client')"
+  [{:keys [project-name] :as opts}]
+  (when-not project-name
+    (throw (ex-info "Missing required :project-name" opts)))
+  (let [target-dir (project-target-dir project-name)]
+    (println "Cleaning" target-dir)
+    (b/delete {:path target-dir})))
+
+(defn jar
+  "Build a JAR file for a project.
+
+  Options:
+    :project-name - Name of the project (e.g., 'server', 'client')
+    :lib - Qualified library name (e.g., io.github.hugoduncan/mcp-clj-server)
+    :src-dirs - Optional vector of source directories to include
+    :resource-dirs - Optional vector of resource directories to include
+
+  The JAR is built as a thin JAR (no dependencies bundled) with pom.xml
+  metadata. Version is automatically determined from git commit count."
+  [{:keys [project-name lib src-dirs resource-dirs] :as opts}]
+  (when-not project-name
+    (throw (ex-info "Missing required :project-name" opts)))
+  (when-not lib
+    (throw (ex-info "Missing required :lib" opts)))
+
+  (let [v (version nil)
+        class-dir (project-class-dir project-name)
+        jar-file (jar-file-path project-name v)
+        project-dir (str root-dir "/projects/" project-name)
+        basis (b/create-basis {:project (str project-dir "/deps.edn")})]
+
+    (println "\nBuilding" lib v)
+    (println "Project:" project-name)
+    (println "JAR file:" jar-file)
+
+    ;; Clean first
+    (clean opts)
+
+;; Copy source files from basis paths and local dependencies
+    (let [basis-paths (:paths basis)
+          ;; Extract paths from local/root dependencies
+          local-deps (filter #(contains? (val %) :local/root) (:libs basis))
+          local-paths (mapcat #(:paths (val %)) local-deps)
+          all-paths (concat basis-paths local-paths)
+          all-src-dirs (or src-dirs all-paths)]
+      (println "Copying sources from:" (count all-src-dirs) "paths")
+      (b/copy-dir {:src-dirs all-src-dirs
+                   :target-dir class-dir}))
+
+    ;; Copy resource files if specified
+    (when resource-dirs
+      (println "Copying resources from:" resource-dirs)
+      (b/copy-dir {:src-dirs resource-dirs
+                   :target-dir class-dir}))
+
+    ;; Write pom.xml
+    (println "Writing pom.xml")
+    (b/write-pom {:class-dir class-dir
+                  :lib lib
+                  :version v
+                  :basis basis
+                  :src-dirs ["src"]})
+
+    ;; Create JAR
+    (println "Creating JAR")
+    (b/jar {:class-dir class-dir
+            :jar-file jar-file})
+
+    (println "\nBuild complete:" jar-file)
+    jar-file))

--- a/projects/client/deps.edn
+++ b/projects/client/deps.edn
@@ -1,2 +1,10 @@
 {:deps
- {poly/mcp-client {:local/root "../../components/mcp-client"}}}
+ {poly/mcp-client {:local/root "../../components/mcp-client"}}
+
+ :aliases
+ {:build {:extra-paths ["../../dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build
+          :exec-fn jar
+          :exec-args {:project-name "client"
+                      :lib io.github.hugoduncan/mcp-clj-client}}}}

--- a/projects/in-memory-transport/deps.edn
+++ b/projects/in-memory-transport/deps.edn
@@ -1,3 +1,11 @@
 {:deps
  {poly/in-memory-transport
-  {:local/root "../../components/in-memory-transport"}}}
+  {:local/root "../../components/in-memory-transport"}}
+
+ :aliases
+ {:build {:extra-paths ["../../dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build
+          :exec-fn jar
+          :exec-args {:project-name "in-memory-transport"
+                      :lib io.github.hugoduncan/mcp-clj-in-memory-transport}}}}

--- a/projects/java-sdk-wrapper/deps.edn
+++ b/projects/java-sdk-wrapper/deps.edn
@@ -1,2 +1,10 @@
 {:deps
- {poly/interop {:local/root "../../components/interop"}}}
+ {poly/interop {:local/root "../../components/interop"}}
+
+ :aliases
+ {:build {:extra-paths ["../../dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build
+          :exec-fn jar
+          :exec-args {:project-name "java-sdk-wrapper"
+                      :lib io.github.hugoduncan/mcp-clj-java-sdk-wrapper}}}}

--- a/projects/server/deps.edn
+++ b/projects/server/deps.edn
@@ -6,4 +6,10 @@
 
  :aliases
  {:sse-server {:main-opts ["-m" "mcp-clj.sse-server.main"]}
-  :stdio-server {:main-opts ["-m" "mcp-clj.stdio-server.main"]}}}
+  :stdio-server {:main-opts ["-m" "mcp-clj.stdio-server.main"]}
+  :build {:extra-paths ["../../dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build
+          :exec-fn jar
+          :exec-args {:project-name "server"
+                      :lib io.github.hugoduncan/mcp-clj-server}}}}

--- a/projects/test-dep/deps.edn
+++ b/projects/test-dep/deps.edn
@@ -3,4 +3,12 @@
   poly/mcp-server {:local/root "../../components/mcp-server"}
   poly/mcp-client {:local/root "../../components/mcp-client"}
   poly/in-memory-transport
-  {:local/root "../../components/in-memory-transport"}}}
+  {:local/root "../../components/in-memory-transport"}}
+
+ :aliases
+ {:build {:extra-paths ["../../dev"]
+          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :ns-default build
+          :exec-fn jar
+          :exec-args {:project-name "test-dep"
+                      :lib io.github.hugoduncan/mcp-clj-test-dep}}}}


### PR DESCRIPTION
## Summary
Add tools.build-based build system that enables building thin JARs for all projects with automatic version numbering from git commit count.

## Changes

### Build Script (dev/build.clj)
- Provides `jar`, `clean`, and `version` functions
- Version format: `0.1.<commit-count>` using `git-count-revs`
- Automatically includes source from all `local/root` dependencies
- Finds repository root to work from any project directory
- JAR naming: `mcp-clj-<project-name>-<version>.jar`

### Project Configuration
Added `:build` alias to all five projects:
- `server` → `mcp-clj-server-0.1.49.jar` (40KB, includes 11 source paths)
- `client` → `mcp-clj-client-0.1.49.jar` (40KB, includes 7 source paths)
- `in-memory-transport` → `mcp-clj-in-memory-transport-0.1.49.jar` (30KB, includes 6 source paths)
- `java-sdk-wrapper` → `mcp-clj-java-sdk-wrapper-<version>.jar`
- `test-dep` → `mcp-clj-test-dep-<version>.jar`

Each alias is configured with project-specific name and lib coordinates.

### Build Artifacts
- Thin JARs (no bundled dependencies) with pom.xml metadata
- Output to `projects/<name>/target/`
- Added `projects/*/target/` to `.gitignore`

### Dependencies
- Added `io.github.clojure/tools.build 0.10.5` to root `deps.edn`
- Added `:build` alias at root level for build script access

## Usage

Build any project JAR:
```bash
cd projects/server
clojure -T:build jar
```

Clean build artifacts:
```bash
clojure -T:build clean
```

Check version:
```bash
clojure -T:build version
```

## Testing

Verified builds for:
- ✅ server project (40KB JAR with all component sources)
- ✅ client project (40KB JAR with all component sources)
- ✅ in-memory-transport project (30KB JAR with all component sources)

All JARs include:
- Source files from local dependencies
- Maven metadata (pom.xml, pom.properties)
- Proper manifest

## Notes

Projects can now be built individually from their directories using the `:build` alias. All projects share the same version number based on git commit count, ensuring consistent versioning across the polylith architecture.

The build system is designed for thin JARs suitable for library distribution. Future enhancements could include uberjar support for standalone deployment.