### PR TITLE
fix: add contents write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Release
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary

Adds `permissions: contents: write` to the release workflow job to fix the 403 error when pushing git tags.

## Problem

The release workflow was failing with:
```
remote: Permission to hugoduncan/mcp-clj.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/hugoduncan/mcp-clj/': The requested URL returned error: 403
```

## Solution

GitHub Actions workflows have read-only `GITHUB_TOKEN` permissions by default. The workflow needs explicit write permission to push tags to the repository.

## Changes

- Added `permissions: contents: write` at the job level in `.github/workflows/release.yml`

## Test Plan

- The workflow should now successfully push tags when run with `dry-run=false`
- The `softprops/action-gh-release@v2` action should also work correctly