### PR TITLE
fix: change artifact group from io.github.hugoduncan to org.hugoduncan

### DIFF
--- a/dev/build.clj
+++ b/dev/build.clj
@@ -5,7 +5,7 @@
   based on git commit count. All projects share the same version number.
 
   Usage:
-    clj -T:build jar :project-name '\"server\"' :lib 'io.github.hugoduncan/mcp-clj-server'
+    clj -T:build jar :project-name '\"server\"' :lib 'org.hugoduncan/mcp-clj-server'
     clj -T:build clean :project-name '\"server\"'
     clj -T:build version
 
@@ -71,7 +71,7 @@
 
   Options:
     :project-name - Name of the project (e.g., 'server', 'client')
-    :lib - Qualified library name (e.g., io.github.hugoduncan/mcp-clj-server)
+    :lib - Qualified library name (e.g., org.hugoduncan/mcp-clj-server)
     :src-dirs - Optional vector of source directories to include
     :resource-dirs - Optional vector of resource directories to include
 
@@ -137,7 +137,7 @@
 
   Options:
     :project-name - Name of the project (e.g., 'server', 'client')
-    :lib - Qualified library name (e.g., io.github.hugoduncan/mcp-clj-server)
+    :lib - Qualified library name (e.g., org.hugoduncan/mcp-clj-server)
 
   Requires CLOJARS_USERNAME and CLOJARS_PASSWORD environment variables or
   Maven settings.xml configuration."

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -83,9 +83,9 @@ This will:
 
 The following projects are released to Clojars:
 
-- `io.github.hugoduncan/mcp-clj-server`
-- `io.github.hugoduncan/mcp-clj-client`
-- `io.github.hugoduncan/mcp-clj-in-memory-transport`
+- `org.hugoduncan/mcp-clj-server`
+- `org.hugoduncan/mcp-clj-client`
+- `org.hugoduncan/mcp-clj-in-memory-transport`
 
 Test-only projects (`test-dep`, `java-sdk-wrapper`) are not released.
 

--- a/projects/client/deps.edn
+++ b/projects/client/deps.edn
@@ -7,11 +7,11 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "client"
-                      :lib io.github.hugoduncan/mcp-clj-client}}
+                      :lib org.hugoduncan/mcp-clj-client}}
   :deploy {:extra-paths ["../../dev"]
            :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                         slipset/deps-deploy {:mvn/version "0.2.2"}}
            :ns-default build
            :exec-fn deploy
            :exec-args {:project-name "client"
-                       :lib io.github.hugoduncan/mcp-clj-client}}}}
+                       :lib org.hugoduncan/mcp-clj-client}}}}

--- a/projects/in-memory-transport/deps.edn
+++ b/projects/in-memory-transport/deps.edn
@@ -8,11 +8,11 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "in-memory-transport"
-                      :lib io.github.hugoduncan/mcp-clj-in-memory-transport}}
+                      :lib org.hugoduncan/mcp-clj-in-memory-transport}}
   :deploy {:extra-paths ["../../dev"]
            :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                         slipset/deps-deploy {:mvn/version "0.2.2"}}
            :ns-default build
            :exec-fn deploy
            :exec-args {:project-name "in-memory-transport"
-                       :lib io.github.hugoduncan/mcp-clj-in-memory-transport}}}}
+                       :lib org.hugoduncan/mcp-clj-in-memory-transport}}}}

--- a/projects/java-sdk-wrapper/deps.edn
+++ b/projects/java-sdk-wrapper/deps.edn
@@ -7,4 +7,4 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "java-sdk-wrapper"
-                      :lib io.github.hugoduncan/mcp-clj-java-sdk-wrapper}}}}
+                      :lib org.hugoduncan/mcp-clj-java-sdk-wrapper}}}}

--- a/projects/server/deps.edn
+++ b/projects/server/deps.edn
@@ -12,11 +12,11 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "server"
-                      :lib io.github.hugoduncan/mcp-clj-server}}
+                      :lib org.hugoduncan/mcp-clj-server}}
   :deploy {:extra-paths ["../../dev"]
            :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                         slipset/deps-deploy {:mvn/version "0.2.2"}}
            :ns-default build
            :exec-fn deploy
            :exec-args {:project-name "server"
-                       :lib io.github.hugoduncan/mcp-clj-server}}}}
+                       :lib org.hugoduncan/mcp-clj-server}}}}

--- a/projects/test-dep/deps.edn
+++ b/projects/test-dep/deps.edn
@@ -11,4 +11,4 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "test-dep"
-                      :lib io.github.hugoduncan/mcp-clj-test-dep}}}}
+                      :lib org.hugoduncan/mcp-clj-test-dep}}}}


### PR DESCRIPTION
## Summary

Changes the Maven group ID from `io.github.hugoduncan` to `org.hugoduncan` for all published artifacts to resolve Clojars deployment authorization errors.

## Problem

The release workflow was failing during deployment to Clojars with a 403 Forbidden error:

```
Could not transfer artifact io.github.hugoduncan:mcp-clj-server:pom:0.1.57 from/to clojars (https://clojars.org/repo): authorization failed for https://clojars.org/repo/io/github/hugoduncan/mcp-clj-server/0.1.57/mcp-clj-server-0.1.57.pom, status: 403 Forbidden - Group 'io.github.hugoduncan'
```

The account does not have permission to publish to the `io.github.hugoduncan` group on Clojars.

## Solution

Updated all project configurations to use `org.hugoduncan` as the group ID instead, which is authorized for the account.

## Changes

- Updated `dev/build.clj` documentation examples
- Updated all project `deps.edn` files (server, client, in-memory-transport, test-dep, java-sdk-wrapper)
- Updated `doc/release-process.md` artifact references

## Affected Artifacts

The following artifacts will now be published under the new group:
- `org.hugoduncan/mcp-clj-server` (previously `io.github.hugoduncan/mcp-clj-server`)
- `org.hugoduncan/mcp-clj-client` (previously `io.github.hugoduncan/mcp-clj-client`)
- `org.hugoduncan/mcp-clj-in-memory-transport` (previously `io.github.hugoduncan/mcp-clj-in-memory-transport`)

## Test Plan

- All existing tests continue to pass (group ID doesn't affect functionality)
- Next release workflow should successfully deploy to Clojars under the new group