### PR TITLE
fix: add missing EPL 2.0 license metadata to client and in-memory-transport projects

### DIFF
--- a/projects/client/deps.edn
+++ b/projects/client/deps.edn
@@ -7,11 +7,31 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "client"
-                      :lib org.hugoduncan/mcp-clj-client}}
+                      :lib org.hugoduncan/mcp-clj-client
+                      :pom-data [[:description "Clojure MCP client for connecting to MCP servers"]
+                                 [:url "https://github.com/hugoduncan/mcp-clj"]
+                                 [:licenses
+                                  [:license
+                                   [:name "Eclipse Public License 2.0"]
+                                   [:url "https://www.eclipse.org/legal/epl-2.0/"]]]
+                                 [:scm
+                                  [:url "https://github.com/hugoduncan/mcp-clj"]
+                                  [:connection "scm:git:git://github.com/hugoduncan/mcp-clj.git"]
+                                  [:developerConnection "scm:git:ssh://git@github.com/hugoduncan/mcp-clj.git"]]]}}
   :deploy {:extra-paths ["../../dev"]
            :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                         slipset/deps-deploy {:mvn/version "0.2.2"}}
            :ns-default build
            :exec-fn deploy
            :exec-args {:project-name "client"
-                       :lib org.hugoduncan/mcp-clj-client}}}}
+                       :lib org.hugoduncan/mcp-clj-client
+                       :pom-data [[:description "Clojure MCP client for connecting to MCP servers"]
+                                  [:url "https://github.com/hugoduncan/mcp-clj"]
+                                  [:licenses
+                                   [:license
+                                    [:name "Eclipse Public License 2.0"]
+                                    [:url "https://www.eclipse.org/legal/epl-2.0/"]]]
+                                  [:scm
+                                   [:url "https://github.com/hugoduncan/mcp-clj"]
+                                   [:connection "scm:git:git://github.com/hugoduncan/mcp-clj.git"]
+                                   [:developerConnection "scm:git:ssh://git@github.com/hugoduncan/mcp-clj.git"]]]}}}}

--- a/projects/in-memory-transport/deps.edn
+++ b/projects/in-memory-transport/deps.edn
@@ -8,11 +8,31 @@
           :ns-default build
           :exec-fn jar
           :exec-args {:project-name "in-memory-transport"
-                      :lib org.hugoduncan/mcp-clj-in-memory-transport}}
+                      :lib org.hugoduncan/mcp-clj-in-memory-transport
+                      :pom-data [[:description "In-memory transport for MCP client-server testing"]
+                                 [:url "https://github.com/hugoduncan/mcp-clj"]
+                                 [:licenses
+                                  [:license
+                                   [:name "Eclipse Public License 2.0"]
+                                   [:url "https://www.eclipse.org/legal/epl-2.0/"]]]
+                                 [:scm
+                                  [:url "https://github.com/hugoduncan/mcp-clj"]
+                                  [:connection "scm:git:git://github.com/hugoduncan/mcp-clj.git"]
+                                  [:developerConnection "scm:git:ssh://git@github.com/hugoduncan/mcp-clj.git"]]]}}
   :deploy {:extra-paths ["../../dev"]
            :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                         slipset/deps-deploy {:mvn/version "0.2.2"}}
            :ns-default build
            :exec-fn deploy
            :exec-args {:project-name "in-memory-transport"
-                       :lib org.hugoduncan/mcp-clj-in-memory-transport}}}}
+                       :lib org.hugoduncan/mcp-clj-in-memory-transport
+                       :pom-data [[:description "In-memory transport for MCP client-server testing"]
+                                  [:url "https://github.com/hugoduncan/mcp-clj"]
+                                  [:licenses
+                                   [:license
+                                    [:name "Eclipse Public License 2.0"]
+                                    [:url "https://www.eclipse.org/legal/epl-2.0/"]]]
+                                  [:scm
+                                   [:url "https://github.com/hugoduncan/mcp-clj"]
+                                   [:connection "scm:git:git://github.com/hugoduncan/mcp-clj.git"]
+                                   [:developerConnection "scm:git:ssh://git@github.com/hugoduncan/mcp-clj.git"]]]}}}}


### PR DESCRIPTION
## Summary

Adds EPL 2.0 license metadata to the client and in-memory-transport projects that was missing from the previous commit.

## Problem

The release workflow was failing with:
```
Could not transfer metadata org.hugoduncan:mcp-clj-client/maven-metadata.xml from/to clojars (https://clojars.org/repo): 
authorization failed for https://clojars.org/repo/org/hugoduncan/mcp-clj-client/maven-metadata.xml, 
status: 403 Forbidden - the POM file does not include a license
```

The previous commit (56c4ff9) only added license metadata to the server project, but there are three projects that can be deployed to Clojars:
- `server` (had license metadata ✓)
- `client` (missing license metadata - causing the failure)
- `in-memory-transport` (also missing license metadata)

## Solution

Added the same `:pom-data` configuration with EPL 2.0 license metadata to both the `:build` and `:deploy` aliases for:
- `projects/client/deps.edn`
- `projects/in-memory-transport/deps.edn`

## Changes

- Added description, URL, license (EPL 2.0), and SCM metadata to client project
- Added description, URL, license (EPL 2.0), and SCM metadata to in-memory-transport project

This ensures all deployable artifacts include proper license information as required by Clojars.