### PR TITLE
Fix nil params handling in session metadata

### DIFF
--- a/components/mcp-server/src/mcp_clj/mcp_server/core.clj
+++ b/components/mcp-server/src/mcp_clj/mcp_server/core.clj
@@ -373,7 +373,7 @@
                         new-session)))
         protocol-version (:protocol-version session)
         ;; Add session-id to params metadata for handlers that need it
-        params-with-session (with-meta params {:session-id session-id})
+        params-with-session (with-meta (or params {}) {:session-id session-id})
         ;; Use version-aware handler for tool calls if protocol version is available
         actual-handler (if (and protocol-version (= handler handle-call-tool))
                          #(version-aware-handle-call-tool %1 protocol-version %2)


### PR DESCRIPTION
I got this error when using gemini with mcp-clj. when there is a /mcp call.  the issue is that `params` can sometimes be `nil` which does not work with `with-meta` it may be better to check for params higher up in the stack rather than this.

```
ERROR [rpc/handler-error] {:error #error {
 :cause "Cannot invoke \"clojure.lang.IObj.withMeta(clojure.lang.IPersistentMap)\" because \"x\" is null"
 :via
 [{:type java.lang.NullPointerException
   :message "Cannot invoke \"clojure.lang.IObj.withMeta(clojure.lang.IPersistentMap)\" because \"x\" is null"
   :at [clojure.core$with_meta__5485 invokeStatic "core.clj" 220]}]
 :trace
 [[clojure.core$with_meta__5485 invokeStatic "core.clj" 220]
  [clojure.core$with_meta__5485 invoke "core.clj" 219]
  [mcp_clj.mcp_server.core$request_handler invokeStatic "core.clj" 376]
  [mcp_clj.mcp_server.core$request_handler invoke "core.clj" 362]
  [mcp_clj.mcp_server.core$create_handlers$fn__43018$fn__43019 invoke "core.clj" 434]
  [mcp_clj.json_rpc.sse_server$handle_json_rpc invokeStatic "sse_server.clj" 42]
  [mcp_clj.json_rpc.sse_server$handle_json_rpc invoke "sse_server.clj" 37]
  [mcp_clj.json_rpc.sse_server$dispatch_rpc_call$fn__43334 invoke "sse_server.clj" 72]
  [mcp_clj.json_rpc.executor$submit_with_timeout_BANG_$fn__43204 invoke "executor.clj" 58]
  [mcp_clj.json_rpc.executor$wrap_log_throwables$fn__43196 invoke "executor.clj" 19]
  [clojure.lang.AFn call "AFn.java" 18]
  [java.util.concurrent.FutureTask run "FutureTask.java" 317]
  [java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask run "ScheduledThreadPoolExecutor.java" 304]
  [java.util.concurrent.ThreadPoolExecutor runWorker "ThreadPoolExecutor.java" 1144]
  [java.util.concurrent.ThreadPoolExecutor$Worker run "ThreadPoolExecutor.java" 642]
  [java.lang.Thread run "Thread.java" 1583]]}} 
```