### PR TITLE
fix: add missing http component dependencies to json-rpc

### DIFF
--- a/components/http-server/deps.edn
+++ b/components/http-server/deps.edn
@@ -1,4 +1,5 @@
-{:deps {poly/http {:local/root "../http"}}
+{:deps {poly/http {:local/root "../http"}
+        poly/log {:local/root "../log"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps  {hato/hato {:mvn/version "1.0.0"}}}}}

--- a/components/json-rpc/deps.edn
+++ b/components/json-rpc/deps.edn
@@ -1,7 +1,10 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        poly/http {:local/root "../http"}
         poly/http-client {:local/root "../http-client"}
-        poly/json {:local/root "../json"}}
+        poly/http-server {:local/root "../http-server"}
+        poly/json {:local/root "../json"}
+        poly/log {:local/root "../log"}}
  :aliases
  {:dev {:extra-paths ["test"]
         :extra-deps {hato/hato {:mvn/version "1.0.0"}}}

--- a/components/json-rpc/test/mcp_clj/json_rpc/deps_test.clj
+++ b/components/json-rpc/test/mcp_clj/json_rpc/deps_test.clj
@@ -1,0 +1,18 @@
+(ns mcp-clj.json-rpc.deps-test
+  "Test to verify json-rpc component dependencies are correctly declared"
+  (:require
+    [clojure.test :refer [deftest is testing]]))
+
+(deftest sse-server-dependencies-test
+  ;; Test that SSE server and its required dependencies can be loaded.
+  ;; This validates that components/json-rpc/deps.edn correctly declares
+  ;; all dependencies needed by the sse-server namespace.
+  (testing "SSE server namespace"
+    (testing "can be loaded with declared dependencies"
+      (is (nil? (require 'mcp-clj.json-rpc.sse-server))
+          "sse-server namespace should load successfully"))
+    (testing "required namespaces are available"
+      (is (nil? (require 'mcp-clj.http))
+          "mcp-clj.http should be available (required by sse-server:4)")
+      (is (nil? (require 'mcp-clj.http-server.adapter))
+          "mcp-clj.http-server.adapter should be available (required by sse-server:5)"))))


### PR DESCRIPTION
Fixes #43

## Summary

The json-rpc component's sse-server namespace requires `mcp-clj.http` and `mcp-clj.http-server.adapter` but these dependencies were not declared in `components/json-rpc/deps.edn`, causing FileNotFoundException at runtime when starting SSE servers.

## Changes

- Added `poly/http` and `poly/http-server` dependencies to `components/json-rpc/deps.edn`
- Added `poly/log` dependency to `components/json-rpc/deps.edn` and `components/http-server/deps.edn`
- Created test to verify required namespaces can be loaded (`components/json-rpc/test/mcp_clj/json_rpc/deps_test.clj`)

## Root Cause

The `components/json-rpc/src/mcp_clj/json_rpc/sse_server.clj` file requires:
- `[mcp-clj.http :as http]` (line 4)
- `[mcp-clj.http-server.adapter :as http-server]` (line 5)

However, `components/json-rpc/deps.edn` did not declare these dependencies, causing runtime failures when users depend on `projects/server` and try to start an SSE server.

## Testing

- New test verifies SSE server namespace and its dependencies can be loaded
- CI will run full test suite including unit and integration tests
- SSE server startup verified locally